### PR TITLE
Update fabrictestbed-extensions to 2.0.6 and fix security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,13 @@ authors = [
 
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["FABRIC", "testbed", "automation", "testing"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Testing"
@@ -28,7 +27,7 @@ classifiers = [
 dependencies = [
     "pytest",
     "requests",
-    "fabrictestbed-extensions>=1.7.3"
+    "fabrictestbed-extensions>=2.0.6"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-urllib3<2.0.0
 pytest
 requests
-fabrictestbed-extensions>=1.7.3
+fabrictestbed-extensions>=2.0.6

--- a/tests/acceptance/test_f_create_storage_vms.py
+++ b/tests/acceptance/test_f_create_storage_vms.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from tests.acceptance.utils import error_message
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _safe_devname
 
 
 VM_CONFIG = {"cores": 10, "ram": 20, "disk": 50}
@@ -107,7 +107,7 @@ def test_attached_storage_parallel(fablib):
 
             node = slice_obj.get_node("storage-node")
             storage = node.get_storage(STORAGE_NAME)
-            device = storage.get_device_name()
+            device = _safe_devname(storage.get_device_name())
             print(f"[{site_name}] Storage device: {device}")
 
             # Format volume

--- a/tests/acceptance/test_g_fabnetv4_shared_nic.py
+++ b/tests/acceptance/test_g_fabnetv4_shared_nic.py
@@ -33,7 +33,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 from tests.acceptance.utils import error_message
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _validate_ip, _safe_devname
 
 
 NIC_MODEL = 'NIC_Basic'
@@ -160,11 +160,11 @@ def test_fabnetv4_sharednic_ping(fablib):
             iface1 = node1.get_interface(network_name="fabnetv4-net1")
             iface2 = node2.get_interface(network_name="fabnetv4-net2")
 
-            ip1 = iface1.get_ip_addr()
-            ip2 = iface2.get_ip_addr()
+            ip1 = _validate_ip(iface1.get_ip_addr())
+            ip2 = _validate_ip(iface2.get_ip_addr())
 
-            node1.execute(f"ip addr show {iface1.get_os_interface()}")
-            node2.execute(f"ip addr show {iface2.get_os_interface()}")
+            node1.execute(f"ip addr show {_safe_devname(iface1.get_device_name())}")
+            node2.execute(f"ip addr show {_safe_devname(iface2.get_device_name())}")
 
             ping_out1, _ = node1.execute(f"ping -c 5 {ip2}")
             ping_out2, _ = node2.execute(f"ping -c 5 {ip1}")

--- a/tests/acceptance/test_h_fabnetv6_shared_nic.py
+++ b/tests/acceptance/test_h_fabnetv6_shared_nic.py
@@ -32,7 +32,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from tests.acceptance.utils import error_message
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _validate_ip, _safe_devname
 
 
 NIC_MODEL = 'NIC_Basic'
@@ -159,11 +159,11 @@ def test_fabnetv6_sharednic_ping(fablib):
             iface1 = node1.get_interface(network_name="fabnetv6-net1")
             iface2 = node2.get_interface(network_name="fabnetv6-net2")
 
-            node1.execute(f"ip -6 addr show {iface1.get_os_interface()}")
-            node2.execute(f"ip -6 addr show {iface2.get_os_interface()}")
+            node1.execute(f"ip -6 addr show {_safe_devname(iface1.get_device_name())}")
+            node2.execute(f"ip -6 addr show {_safe_devname(iface2.get_device_name())}")
 
-            ip1 = iface1.get_ip_addr()
-            ip2 = iface2.get_ip_addr()
+            ip1 = _validate_ip(iface1.get_ip_addr())
+            ip2 = _validate_ip(iface2.get_ip_addr())
 
             ping_out1, _ = node1.execute(f"ping6 -c 5 {ip2}")
             ping_out2, _ = node2.execute(f"ping6 -c 5 {ip1}")

--- a/tests/acceptance/test_i_l2bridge_shared_nic.py
+++ b/tests/acceptance/test_i_l2bridge_shared_nic.py
@@ -30,7 +30,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
 from tests.acceptance.utils import error_message
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _validate_ip
 
 
 NIC_MODEL = 'NIC_Basic'
@@ -125,11 +125,11 @@ def test_sharednic_local_bridge_reachability(fablib):
 
             # Configure Node1
             iface1 = node1.get_interface(network_name=NETWORK_NAME)
-            ip1 = iface1.get_ip_addr()
+            ip1 = _validate_ip(iface1.get_ip_addr())
 
             # Configure Node2
             iface2 = node2.get_interface(network_name=NETWORK_NAME)
-            ip2 = iface2.get_ip_addr()
+            ip2 = _validate_ip(iface2.get_ip_addr())
 
             # Test ping
             stdout, stderr = node1.execute(f"ping -c 5 {ip2}")

--- a/tests/acceptance/test_j_l2bridge_smart_nic.py
+++ b/tests/acceptance/test_j_l2bridge_smart_nic.py
@@ -30,7 +30,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
 from tests.acceptance.utils import error_message
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _validate_ip
 
 
 SMART_NIC_MODELS = ['NIC_ConnectX_5', 'NIC_ConnectX_6']
@@ -123,10 +123,10 @@ def test_smartnic_local_bridge_reachability(fablib):
 
             # Assign IPs
             iface1 = node1.get_interface(network_name=NETWORK_NAME)
-            ip1 = iface1.get_ip_addr()
+            ip1 = _validate_ip(iface1.get_ip_addr())
 
             iface2 = node2.get_interface(network_name=NETWORK_NAME)
-            ip2 = iface2.get_ip_addr()
+            ip2 = _validate_ip(iface2.get_ip_addr())
 
             # Test reachability
             stdout, stderr = node1.execute(f"ping -c 5 {ip2}")

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -32,7 +32,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
 from tests.acceptance.utils import error_message
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _validate_ip
 
 
 VM_CONFIG = {"cores": 10, "ram": 20, "disk": 50}
@@ -147,10 +147,10 @@ def test_smartnic_l2ptp_across_sites(fablib):
             node2 = slice_obj.get_node("node2")
 
             iface1 = node1.get_interface(network_name=NETWORK_NAME)
-            ip1 = iface1.get_ip_addr()
+            ip1 = _validate_ip(iface1.get_ip_addr())
 
             iface2 = node2.get_interface(network_name=NETWORK_NAME)
-            ip2 = iface2.get_ip_addr()
+            ip2 = _validate_ip(iface2.get_ip_addr())
 
             stdout, _ = node1.execute(f"ping -c 5 {ip2}")
             assert "0% packet loss" in stdout, f"[{key}] Ping failed"

--- a/tests/acceptance/test_l_l2sts_shared_nic.py
+++ b/tests/acceptance/test_l_l2sts_shared_nic.py
@@ -32,7 +32,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
 from tests.acceptance.utils import error_message
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _validate_ip, _safe_devname
 
 
 NIC_MODEL = 'NIC_Basic'
@@ -152,13 +152,13 @@ def test_l2sts_sharednic_ping(fablib):
             iface2 = node2.get_interface(network_name=NETWORK_NAME)
             iface3 = node3.get_interface(network_name=NETWORK_NAME)
 
-            ip1 = iface1.get_ip_addr()
-            ip2 = iface2.get_ip_addr()
-            ip3 = iface3.get_ip_addr()
+            ip1 = _validate_ip(iface1.get_ip_addr())
+            ip2 = _validate_ip(iface2.get_ip_addr())
+            ip3 = _validate_ip(iface3.get_ip_addr())
 
-            node1.execute(f"ip addr show {iface1.get_os_interface()}")
-            node2.execute(f"ip addr show {iface2.get_os_interface()}")
-            node3.execute(f"ip addr show {iface3.get_os_interface()}")
+            node1.execute(f"ip addr show {_safe_devname(iface1.get_device_name())}")
+            node2.execute(f"ip addr show {_safe_devname(iface2.get_device_name())}")
+            node3.execute(f"ip addr show {_safe_devname(iface3.get_device_name())}")
 
             stdout, _ = node1.execute(f"ping -c 5 {ip2}")
             assert "0% packet loss" in stdout, f"[{key}] Ping failed"

--- a/tests/acceptance/test_m_l2sts_smart_nic.py
+++ b/tests/acceptance/test_m_l2sts_smart_nic.py
@@ -32,7 +32,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
 from tests.acceptance.utils import error_message
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _validate_ip, _safe_devname
 
 
 NIC_MODEL = 'NIC_ConnectX_5'
@@ -147,17 +147,17 @@ def test_l2sts_smartnic_ping(fablib):
             iface2 = node2.get_interface(network_name=NETWORK_NAME)
             iface3 = node3.get_interface(network_name=NETWORK_NAME)
 
-            ip1 = iface1.get_ip_addr()
-            ip2 = iface2.get_ip_addr()
-            ip3 = iface3.get_ip_addr()
+            ip1 = _validate_ip(iface1.get_ip_addr())
+            ip2 = _validate_ip(iface2.get_ip_addr())
+            ip3 = _validate_ip(iface3.get_ip_addr())
 
             iface1.ip_addr_add(addr=ip1, subnet=SUBNET)
             iface2.ip_addr_add(addr=ip2, subnet=SUBNET)
             iface3.ip_addr_add(addr=ip3, subnet=SUBNET)
 
-            node1.execute(f"ip addr show {iface1.get_os_interface()}")
-            node2.execute(f"ip addr show {iface2.get_os_interface()}")
-            node3.execute(f"ip addr show {iface3.get_os_interface()}")
+            node1.execute(f"ip addr show {_safe_devname(iface1.get_device_name())}")
+            node2.execute(f"ip addr show {_safe_devname(iface2.get_device_name())}")
+            node3.execute(f"ip addr show {_safe_devname(iface3.get_device_name())}")
 
             stdout, _ = node1.execute(f"ping -c 5 {ip2}")
             assert "0% packet loss" in stdout, f"[{key}] Ping failed"

--- a/tests/acceptance/test_mtu_shared_nic.py
+++ b/tests/acceptance/test_mtu_shared_nic.py
@@ -27,7 +27,7 @@ import re
 import time
 import shlex
 from fabrictestbed_extensions.fablib.fablib import FablibManager
-from tests.base_test import fabric_rc, fim_lock
+from tests.base_test import fabric_rc, fim_lock, _validate_ip
 
 
 SLICE_PREFIX = 'mtu@'
@@ -97,8 +97,8 @@ def test_mtu_probe(fablib):
 
         for site, slice_obj in slices.items():
             node = slice_obj.get_node('node')
-            ipv4 = str(slice_obj.get_l3network('net4').get_available_ips()[0])
-            ipv6 = str(slice_obj.get_l3network('net6').get_available_ips()[0])
+            ipv4 = _validate_ip(slice_obj.get_l3network('net4').get_available_ips()[0])
+            ipv6 = _validate_ip(slice_obj.get_l3network('net6').get_available_ips()[0])
             addrs[site] = {4: ipv4, 6: ipv6}
             print(f"[{site}] IPv4: {ipv4} | IPv6: {ipv6}")
 
@@ -109,7 +109,7 @@ def test_mtu_probe(fablib):
             cmds = []
             for af in [4, 6]:
                 intf = node.get_interface(network_name=f'net{af}')
-                devname = intf.get_os_interface()
+                devname = intf.get_device_name()
                 addr = addrs[site][af]
                 net = intf.get_network()
                 cmds += [
@@ -120,7 +120,7 @@ def test_mtu_probe(fablib):
                 ]
                 for dst_site in slices:
                     if dst_site != site:
-                        cmds.append(f"sudo ip -{af} route replace {addrs[dst_site][af]} via {net.get_gateway()}")
+                        cmds.append(f"sudo ip -{af} route replace {addrs[dst_site][af]} via {_validate_ip(net.get_gateway())}")
             stdout, stderr = node.execute('\n'.join(cmds))
             if stderr:
                 print(f"[{site}] Interface config errors:\n{stderr}")

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -23,6 +23,8 @@
 # SOFTWARE.
 import ipaddress
 import os
+import re
+import shlex
 import socket
 import time
 import unittest
@@ -33,6 +35,22 @@ from fabrictestbed_extensions.fablib.node import Node
 from threading import Lock
 
 fim_lock = Lock()
+
+_DEVNAME_RE = re.compile(r'^[a-zA-Z0-9._-]+$')
+
+
+def _validate_ip(addr_str):
+    """Validate and return a string IP address. Raises ValueError on bad input."""
+    return str(ipaddress.ip_address(str(addr_str)))
+
+
+def _safe_devname(name):
+    """Validate a device name and return it shell-quoted. Raises ValueError on bad input."""
+    name = str(name)
+    if not _DEVNAME_RE.match(name):
+        raise ValueError(f"Invalid device name: {name!r}")
+    return shlex.quote(name)
+
 
 DEBUG = False
 if not DEBUG:
@@ -82,7 +100,7 @@ class BaseTest(unittest.TestCase):
         self.assertIsNotNone(node2)
         node1 = self._slice.get_node(node1.get_name())
         node2 = self._slice.get_node(node2.get_name())
-        node2_address = node2.get_interface(network_name=network_name).get_ip_addr()
+        node2_address = _validate_ip(node2.get_interface(network_name=network_name).get_ip_addr())
         self.assertIsNotNone(node2_address)
         stdout, stderr = node1.execute(f'ping -c 5 {node2_address}')
         self.assertTrue("5 packets transmitted, 5 received" in stdout, "ping failed")

--- a/tests/daily/test_iPerf.py
+++ b/tests/daily/test_iPerf.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
 import pytest
+from tests.base_test import _validate_ip
 from tests.daily.slice_helper import (
     get_fablib,
     delete_existing_slices,
@@ -74,7 +75,7 @@ def test_site_worker_pair_ping_iperf(fablib):
 
         src_node = slices[src].get_node("node")
         dst_node = slices[dst].get_node("node")
-        dst_ip = ip_map[dst]
+        dst_ip = _validate_ip(ip_map[dst])
         pair_key = f"{src}->{dst}"
 
         print(f"Testing {pair_key}...")

--- a/tests/system/test_fabnet_v4_ext_renew_slice.py
+++ b/tests/system/test_fabnet_v4_ext_renew_slice.py
@@ -22,8 +22,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
+import shlex
 from datetime import datetime
-from tests.base_test import BaseTest
+from tests.base_test import BaseTest, _validate_ip, _safe_devname
 
 
 class FabNetv4ExtRenewSliceTest(BaseTest):
@@ -98,10 +99,10 @@ class FabNetv4ExtRenewSliceTest(BaseTest):
         node1_iface.ip_addr_add(addr=node1_addr, subnet=network1.get_subnet())
 
         # Add route to external network Google DNS server in this case
-        stdout, stderr = node1.execute(f'sudo ip route add 8.8.8.0/24 via {network1.get_gateway()}')
+        stdout, stderr = node1.execute(f'sudo ip route add 8.8.8.0/24 via {_validate_ip(network1.get_gateway())}')
         self.assertEqual("", stderr)
 
-        stdout, stderr = node1.execute(f'ip addr show {node1_iface.get_device_name()}')
+        stdout, stderr = node1.execute(f'ip addr show {_safe_devname(node1_iface.get_device_name())}')
         self.assertEqual("", stderr)
 
         stdout, stderr = node1.execute(f'ip route list')
@@ -114,10 +115,10 @@ class FabNetv4ExtRenewSliceTest(BaseTest):
         node2_iface.ip_addr_add(addr=node2_addr, subnet=network2.get_subnet())
 
         # Add route to external network Google DNS server in this case
-        stdout, stderr = node2.execute(f'sudo ip route add 8.8.8.0/24 via {network2.get_gateway()}')
+        stdout, stderr = node2.execute(f'sudo ip route add 8.8.8.0/24 via {_validate_ip(network2.get_gateway())}')
         self.assertEqual("", stderr)
 
-        stdout, stderr = node2.execute(f'ip addr show {node2_iface.get_device_name()}')
+        stdout, stderr = node2.execute(f'ip addr show {_safe_devname(node2_iface.get_device_name())}')
         self.assertEqual("", stderr)
 
         stdout, stderr = node2.execute(f'ip route list')
@@ -126,13 +127,13 @@ class FabNetv4ExtRenewSliceTest(BaseTest):
         # VERIFICATION
         # Ping Google's DNS server from Node1 via the FabNetv4Ext network
         stdout, stderr = node1.execute(
-            f"sudo ping -c 5 8.8.8.8 -I {node1.get_interface(network_name=network1_name).get_device_name()}")
+            f"sudo ping -c 5 8.8.8.8 -I {_safe_devname(node1.get_interface(network_name=network1_name).get_device_name())}")
         self.assertTrue("5 packets transmitted, 5 received" in stdout)
         self.assertEqual("", stderr)
 
         # Ping Google's DNS server from Node2 via the FabNetv4Ext network
         stdout, stderr = node2.execute(
-            f"sudo ping -c 5 8.8.8.8 -I {node2.get_interface(network_name=network2_name).get_device_name()}")
+            f"sudo ping -c 5 8.8.8.8 -I {_safe_devname(node2.get_interface(network_name=network2_name).get_device_name())}")
         print(stdout)
         print(stderr)
         self.assertTrue("5 packets transmitted, 5 received" in stdout)

--- a/tests/system/test_fabnet_v6_ext.py
+++ b/tests/system/test_fabnet_v6_ext.py
@@ -34,7 +34,7 @@
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
 
-from tests.base_test import BaseTest
+from tests.base_test import BaseTest, _validate_ip, _safe_devname
 
 
 class FabNetv6ExtSliceTest(BaseTest):
@@ -115,11 +115,11 @@ class FabNetv6ExtSliceTest(BaseTest):
         # Add route to external network
         # Please be careful when configuring routes using external network. Do not make these routes default to avoid loosing connections to management network destinations.
         stdout, stderr = node1.execute(
-            f'sudo ip route add {external_network_subnet} via {network1.get_gateway()} dev {node1_iface.get_device_name()}')
+            f'sudo ip route add {external_network_subnet} via {_validate_ip(network1.get_gateway())} dev {_safe_devname(node1_iface.get_device_name())}')
 
         self.assertEqual("", stderr, "sudo ip route add failed")
 
-        stdout, stderr = node1.execute(f'sudo ip addr show {node1_iface.get_device_name()}')
+        stdout, stderr = node1.execute(f'sudo ip addr show {_safe_devname(node1_iface.get_device_name())}')
         self.assertEqual("", stderr, "sudo ip addr show failed")
 
         stdout, stderr = node1.execute(f'sudo ip -6 route list')
@@ -133,10 +133,10 @@ class FabNetv6ExtSliceTest(BaseTest):
 
         # Add route to external network
         stdout, stderr = node2.execute(
-            f'sudo ip route add {external_network_subnet} via {network2.get_gateway()} dev {node2_iface.get_device_name()}')
+            f'sudo ip route add {external_network_subnet} via {_validate_ip(network2.get_gateway())} dev {_safe_devname(node2_iface.get_device_name())}')
         self.assertEqual("", stderr)
 
-        stdout, stderr = node2.execute(f'sudo ip addr show {node2_iface.get_device_name()}')
+        stdout, stderr = node2.execute(f'sudo ip addr show {_safe_devname(node2_iface.get_device_name())}')
         self.assertEqual("", stderr, "sudo ip addr show failed")
 
         stdout, stderr = node2.execute(f'sudo ip -6 route list')
@@ -144,11 +144,11 @@ class FabNetv6ExtSliceTest(BaseTest):
 
         # VERIFICATION
         # Verify external connectivity
-        stdout, stderr = node1.execute(f'sudo ping -c 5 -I {node1_iface.get_device_name()} bing.com')
+        stdout, stderr = node1.execute(f'sudo ping -c 5 -I {_safe_devname(node1_iface.get_device_name())} bing.com')
         self.assertTrue("5 packets transmitted, 5 received" in stdout)
         self.assertEqual("", stderr, "ping failed")
 
-        stdout, stderr = node1.execute(f'sudo ping -c 5 -I {node2_iface.get_device_name()} bing.com')
+        stdout, stderr = node1.execute(f'sudo ping -c 5 -I {_safe_devname(node2_iface.get_device_name())} bing.com')
         self.assertTrue("5 packets transmitted, 5 received" in stdout)
         self.assertEqual("", stderr, "ping failed")
         # VERIFICATION

--- a/tests/system/test_gpu_slice.py
+++ b/tests/system/test_gpu_slice.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
+import re
 from tests.base_test import BaseTest
 
 
@@ -70,6 +71,9 @@ class GpuSliceTest(BaseTest):
         distro = 'ubuntu2204'
         version = '12.6'
         architecture = 'x86_64'
+
+        if not re.match(r'^\d+\.\d+$', version):
+            raise ValueError(f"Invalid CUDA version string: {version!r}")
 
         # install prerequisites
         commands = [

--- a/tests/system/test_mf_lib_slice.py
+++ b/tests/system/test_mf_lib_slice.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 from ipaddress import IPv4Network
 
-from fabrictestbed_extensions.fablib.fablib import fablib
-
 from tests.base_test import BaseTest
 
 
@@ -34,7 +32,7 @@ class MflibSliceTest(BaseTest):
         super(MflibSliceTest, self).setUp()
 
     def test_slice(self):
-        [site1] = fablib.get_random_sites(count=1)
+        [site1] = self._fablib.get_random_sites(count=1)
         print(f"Sites: {site1}")
 
         node1_name = 'Node1'

--- a/tests/system/test_modify_slice.py
+++ b/tests/system/test_modify_slice.py
@@ -25,8 +25,6 @@
 
 from ipaddress import IPv4Network
 
-from fabrictestbed_extensions.fablib.fablib import fablib
-
 from tests.base_test import BaseTest
 
 
@@ -36,7 +34,7 @@ class ModifySliceTest(BaseTest):
         super(ModifySliceTest, self).setUp()
 
     def test_slice(self):
-        [site1, site2, site3] = fablib.get_random_sites(count=3)
+        [site1, site2, site3] = self._fablib.get_random_sites(count=3)
 
         print(f"Sites: {site1}, {site2}, {site3}")
 

--- a/tests/system/test_persistent_storage_slice.py
+++ b/tests/system/test_persistent_storage_slice.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
 
-from tests.base_test import BaseTest
+from tests.base_test import BaseTest, _safe_devname
 
 
 class PersistentStorageSliceTest(BaseTest):
@@ -58,7 +58,7 @@ class PersistentStorageSliceTest(BaseTest):
         #self.assertEqual("", stderr, "Filesystem install on storage failed")
 
         stdout, stderr = node.execute(f"sudo mkdir /mnt/fabric_storage; "
-                                      f"sudo mount {storage.get_device_name()} /mnt/fabric_storage; "
+                                      f"sudo mount {_safe_devname(storage.get_device_name())} /mnt/fabric_storage; "
                                       f"df -h")
         self.assertEqual("", stderr, "Mound failed")
         # VERIFICATION


### PR DESCRIPTION
## Summary

- **Fix broken imports**: Replace removed `fablib` singleton import with `self._fablib` in `test_mf_lib_slice.py` and `test_modify_slice.py`
- **Replace deprecated API**: Replace `get_os_interface()` with `get_device_name()` across 5 acceptance tests
- **Fix command injection**: Add `_validate_ip()` and `_safe_devname()` helpers to `base_test.py` and apply input sanitization across 13 test files that interpolate API-returned values into `node.execute()` shell commands
- **Update dependencies**: Require `fabrictestbed-extensions>=2.0.6` and `Python>=3.10`, remove obsolete `urllib3<2.0.0` pin

## Test plan

- [x] Verify all modified files compile cleanly (`python -m py_compile`)
- [x] Confirm no remaining `get_os_interface` calls: `grep -r "get_os_interface" tests/`
- [x] Confirm no remaining singleton imports: `grep -r "from fabrictestbed_extensions.fablib.fablib import fablib" tests/`
- [x] Run acceptance tests against a live FABRIC environment
- [x] Run system tests (`pytest tests/system/`) against a live FABRIC environment