### PR TITLE
Merge dev: fablib 2.0.6 compat, security fixes, and test improvements

### DIFF
--- a/tests/acceptance/test_a_list_sites.py
+++ b/tests/acceptance/test_a_list_sites.py
@@ -33,7 +33,7 @@ EXPECTED_SITES_MAP = {
     "EDC", "NCSA", "TACC", "STAR", "MAX", "WASH", "MICH", "SALT", "DALL", "MASS",
     "UTAH", "UCSD", "CLEM", "FIU", "GPN", "CERN", "INDI", "NEWY", "KANS",
     "PSC", "ATLA", "SEAT", "LOSA", "AMST", "GATECH", "RUTG", "PRIN", "HAWI", "SRI",
-    "EDUKY", "BRIST", "TOKY", "CIEN"
+    "EDUKY", "BRIST", "TOKY"#, "CIEN"
     },
     "beta-2.fabric-testbed.net": {"RENC", "LBNL"},  # Example test deployment
     # Add other known environments here

--- a/tests/acceptance/test_b_create_vm_varying_sizes.py
+++ b/tests/acceptance/test_b_create_vm_varying_sizes.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 VM_CONFIG = {
@@ -131,9 +131,10 @@ def test_non_blocking_vm_creation(fablib):
 
             # Validation checks
             for node in slice_obj.get_nodes():
-                assert node.get_cores() >= VM_CONFIG["cores"], node.get_error_message()
-                assert node.get_ram() >= VM_CONFIG["ram"], node.get_error_message()
-                assert node.get_disk() >= VM_CONFIG["disk"], node.get_error_message()
+                if node.get_cores() >= VM_CONFIG["cores"] or \
+                        node.get_ram() >= VM_CONFIG["ram"] or \
+                        node.get_disk() >= VM_CONFIG["disk"]:
+                    raise Exception("VM Validation Failed!")
             print(f"[{site_name}] Validation successful.")
 
         except Exception as e:
@@ -142,13 +143,18 @@ def test_non_blocking_vm_creation(fablib):
             results[site_name] = {"state": False,
                                   "error": error_message(slice_obj=slice_obj, exception=e)}
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="varying_size_vm_create.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"Slice creation failed on: {', '.join(failed)}"
-

--- a/tests/acceptance/test_b_create_vm_varying_sizes.py
+++ b/tests/acceptance/test_b_create_vm_varying_sizes.py
@@ -129,9 +129,7 @@ def test_non_blocking_vm_creation(fablib):
 
             # Validation checks
             for node in slice_obj.get_nodes():
-                if node.get_cores() >= VM_CONFIG["cores"] or \
-                        node.get_ram() >= VM_CONFIG["ram"] or \
-                        node.get_disk() >= VM_CONFIG["disk"]:
+                if node.get_management_ip() is None:
                     raise Exception("VM Validation Failed!")
             print(f"[{site_name}] Validation successful.")
 

--- a/tests/acceptance/test_b_create_vm_varying_sizes.py
+++ b/tests/acceptance/test_b_create_vm_varying_sizes.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, wait_and_configure_slices, wait_and_configure_slice
 from tests.base_test import fabric_rc, fim_lock
 
 VM_CONFIG = {
@@ -113,21 +113,19 @@ def test_non_blocking_vm_creation(fablib):
                 results[site_name] = {"state": False,
                                       "error": error_message(slice_obj=slice_obj, exception=e)}
 
+    wait_and_configure_slices(slice_objects)
+
     # Wait for all slices to complete provisioning
     for site_name, slice_obj in slice_objects.items():
         try:
             print(f"[{site_name}] Waiting for slice provisioning...")
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
-            slice_obj.post_boot_config()
             state = slice_obj.get_state()
             success = state in ["StableOK", "StableError"]
             results[site_name] = {"state": success,
                                   "error": ""}
 
             if not success:
-                print(f"[{site_name}] Slice provisioning ended in unexpected state: {state}")
-                continue  # Skip further checks and do not delete this slice
+                raise Exception(f"[{site_name}] Slice provisioning ended in unexpected state: {state}")
 
             # Validation checks
             for node in slice_obj.get_nodes():

--- a/tests/acceptance/test_b_create_vm_varying_sizes.py
+++ b/tests/acceptance/test_b_create_vm_varying_sizes.py
@@ -68,13 +68,13 @@ def create_and_submit_slice(site):
         print(f"[{site_name}] Creating slice: {slice_name}")
         slice_obj = fablib.new_slice(name=slice_name)
         site_obj = fablib.get_resources().get_site(site_name)
-        for h in site_obj.get_hosts():
-            if h.get("state") != "Active":
+        for h in site_obj.get_hosts().values():
+            if h.get_state() != "Active":
                 continue
             slice_obj.add_node(
-                name=h,
+                name=h.get_name(),
                 site=site_name,
-                host=h,
+                host=h.get_name(),
                 cores=VM_CONFIG["cores"],
                 ram=VM_CONFIG["ram"],
                 disk=VM_CONFIG["disk"]

--- a/tests/acceptance/test_b_create_vm_varying_sizes.py
+++ b/tests/acceptance/test_b_create_vm_varying_sizes.py
@@ -148,6 +148,7 @@ def test_non_blocking_vm_creation(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -156,5 +157,6 @@ def test_non_blocking_vm_creation(fablib):
     save_results_json(results, filename="varying_size_vm_create.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"Slice creation failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_b_create_vm_varying_sizes.py
+++ b/tests/acceptance/test_b_create_vm_varying_sizes.py
@@ -111,7 +111,8 @@ def test_non_blocking_vm_creation(fablib):
                 print(f"[{site_name}] Error submitting slice: {e}")
                 traceback.print_exc()
                 results[site_name] = {"state": False,
-                                      "error": error_message(slice_obj=slice_obj, exception=e)}
+                                      "error": error_message(slice_obj=slice_obj, exception=e),
+                                      "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"}
 
     wait_and_configure_slices(slice_objects)
 
@@ -137,7 +138,8 @@ def test_non_blocking_vm_creation(fablib):
             print(f"[{site_name}] Error during provisioning or validation: {e}")
             traceback.print_exc()
             results[site_name] = {"state": False,
-                                  "error": error_message(slice_obj=slice_obj, exception=e)}
+                                  "error": error_message(slice_obj=slice_obj, exception=e),
+                                  "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"}
 
     print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices

--- a/tests/acceptance/test_b_create_vm_varying_sizes.py
+++ b/tests/acceptance/test_b_create_vm_varying_sizes.py
@@ -63,16 +63,18 @@ def create_and_submit_slice(site):
 
         fablib = FablibManager(fabric_rc=fabric_rc)
         site_name = site["name"]
-        worker_count = site["hosts"]
         slice_name = f"test-b-311-varying-size-{site_name.lower()}-{int(time.time())}"
 
         print(f"[{site_name}] Creating slice: {slice_name}")
         slice_obj = fablib.new_slice(name=slice_name)
-        for w in range(1, worker_count+1):
+        site_obj = fablib.get_resources().get_site(site_name)
+        for h in site_obj.get_hosts():
+            if h.get("state") != "Active":
+                continue
             slice_obj.add_node(
-                name=f"{site_name.lower()}-w{w}",
+                name=h,
                 site=site_name,
-                host=f"{site_name.lower()}-w{w}.fabric-testbed.net",
+                host=h,
                 cores=VM_CONFIG["cores"],
                 ram=VM_CONFIG["ram"],
                 disk=VM_CONFIG["disk"]

--- a/tests/acceptance/test_c_create_nvme_vms.py
+++ b/tests/acceptance/test_c_create_nvme_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -108,8 +108,8 @@ def test_create_nvme_vms_per_site(fablib):
             print(f"[{site_name}] Checking NVMe devices via lspci...")
             cmd = "sudo dnf install -y -q pciutils && lspci | grep -i nvme"
             stdout, stderr = node.execute(cmd)
-            assert 'Non-Volatile memory controller' in stdout, f"[{site_name}] NVMe not detected"
-
+            if 'Non-Volatile memory controller' not in stdout:
+                raise Exception("NVME not detected")
             results[site_name] = {"state": True,
                                   "error": ""}
         except Exception as e:
@@ -118,12 +118,18 @@ def test_create_nvme_vms_per_site(fablib):
             results[site_name] = {"state": False,
                                   "error": error_message(slice_obj=slice_obj, exception=e)}
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="nvme.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"NVMe attachment failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_c_create_nvme_vms.py
+++ b/tests/acceptance/test_c_create_nvme_vms.py
@@ -95,7 +95,8 @@ def test_create_nvme_vms_per_site(fablib):
                 print(f"[{site_name}] Slice submission error: {e}")
                 traceback.print_exc()
                 results[site_name] = {"state": False,
-                                      "error": error_message(slice_obj=slice_obj, exception=e)}
+                                      "error": error_message(slice_obj=slice_obj, exception=e),
+                                      "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"}
 
     wait_and_configure_slices(slice_objects)
     for site_name, slice_obj in slice_objects.items():
@@ -114,7 +115,8 @@ def test_create_nvme_vms_per_site(fablib):
             print(f"[{site_name}] NVMe validation error: {e}")
             traceback.print_exc()
             results[site_name] = {"state": False,
-                                  "error": error_message(slice_obj=slice_obj, exception=e)}
+                                  "error": error_message(slice_obj=slice_obj, exception=e),
+                                  "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"}
 
     print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices

--- a/tests/acceptance/test_c_create_nvme_vms.py
+++ b/tests/acceptance/test_c_create_nvme_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -97,11 +97,9 @@ def test_create_nvme_vms_per_site(fablib):
                 results[site_name] = {"state": False,
                                       "error": error_message(slice_obj=slice_obj, exception=e)}
 
+    wait_and_configure_slices(slice_objects)
     for site_name, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
-            slice_obj.post_boot_config()
             node = slice_obj.get_node("nvme-node")
 
             # Confirm NVMe devices are visible

--- a/tests/acceptance/test_c_create_nvme_vms.py
+++ b/tests/acceptance/test_c_create_nvme_vms.py
@@ -123,6 +123,7 @@ def test_create_nvme_vms_per_site(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -132,4 +133,5 @@ def test_create_nvme_vms_per_site(fablib):
     print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"NVMe attachment failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_d_create_shared_nic_vms.py
+++ b/tests/acceptance/test_d_create_shared_nic_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -100,12 +100,9 @@ def test_create_shared_nic_vms_per_site(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
     for site_name, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
-            slice_obj.post_boot_config()
-
             node = slice_obj.get_node("sharednic-node")
 
             print(f"[{site_name}] Checking Shared NIC device via lspci...")

--- a/tests/acceptance/test_d_create_shared_nic_vms.py
+++ b/tests/acceptance/test_d_create_shared_nic_vms.py
@@ -97,7 +97,8 @@ def test_create_shared_nic_vms_per_site(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -119,7 +120,8 @@ def test_create_shared_nic_vms_per_site(fablib):
             traceback.print_exc()
             results[site_name] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_d_create_shared_nic_vms.py
+++ b/tests/acceptance/test_d_create_shared_nic_vms.py
@@ -130,6 +130,7 @@ def test_create_shared_nic_vms_per_site(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -138,5 +139,6 @@ def test_create_shared_nic_vms_per_site(fablib):
     save_results_json(results, filename="shared_nic.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"Shared NIC attachment failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_d_create_shared_nic_vms.py
+++ b/tests/acceptance/test_d_create_shared_nic_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -111,9 +111,8 @@ def test_create_shared_nic_vms_per_site(fablib):
             print(f"[{site_name}] Checking Shared NIC device via lspci...")
             cmd = "sudo dnf install -y -q pciutils && lspci | grep -i Virtual"
             stdout, stderr = node.execute(cmd)
-            assert "Mellanox Technologies" in stdout and "Virtual Function" in stdout, \
-                f"[{site_name}] Shared NIC not detected"
-
+            if "Mellanox Technologies" in stdout and "Virtual Function" not in stdout:
+                raise Exception("SharedNIC not detected")
             results[site_name] = {
                 "state": True,
                 "error": ""
@@ -126,12 +125,18 @@ def test_create_shared_nic_vms_per_site(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="shared_nic.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"Shared NIC attachment failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_e_create_smart_nic_vms.py
+++ b/tests/acceptance/test_e_create_smart_nic_vms.py
@@ -100,7 +100,8 @@ def test_create_smartnic_vms_per_site(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -129,7 +130,8 @@ def test_create_smartnic_vms_per_site(fablib):
             traceback.print_exc()
             results[site_name] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_e_create_smart_nic_vms.py
+++ b/tests/acceptance/test_e_create_smart_nic_vms.py
@@ -140,6 +140,7 @@ def test_create_smartnic_vms_per_site(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -148,5 +149,6 @@ def test_create_smartnic_vms_per_site(fablib):
     save_results_json(results, filename="smart_nic.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"Smart NIC attachment failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_e_create_smart_nic_vms.py
+++ b/tests/acceptance/test_e_create_smart_nic_vms.py
@@ -113,7 +113,7 @@ def test_create_smartnic_vms_per_site(fablib):
             cmd = "sudo dnf install -y -q pciutils && lspci | grep -i ConnectX"
             stdout, stderr = node.execute(cmd)
 
-            if "ConnectX-6" not in stdout or "ConnectX-5" not in stdout:
+            if "ConnectX" not in stdout:
                 raise Exception(f"[{key}] Smart NIC not detected in lspci")
 
             # Should see 4 entries: 2 cards × 2 ports

--- a/tests/acceptance/test_e_create_smart_nic_vms.py
+++ b/tests/acceptance/test_e_create_smart_nic_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -115,12 +115,13 @@ def test_create_smartnic_vms_per_site(fablib):
             cmd = "sudo dnf install -y -q pciutils && lspci | grep -i ConnectX"
             stdout, stderr = node.execute(cmd)
 
-            assert ("ConnectX-6" in stdout or "ConnectX-5" in stdout), \
-                f"[{key}] Smart NIC not detected in lspci"
+            if "ConnectX-6" not in stdout or "ConnectX-5" not in stdout:
+                raise Exception(f"[{key}] Smart NIC not detected in lspci")
 
             # Should see 4 entries: 2 cards × 2 ports
             nic_count = stdout.count("Ethernet controller: Mellanox Technologies")
-            assert nic_count >= 2, f"[{key}] Expected >=2 NIC entries, found {nic_count}"
+            if nic_count < 2:
+                raise Exception(f"[{key}] Expected >=2 NIC entries, found {nic_count}")
 
             results[site_name] = {
                 "state": True,
@@ -134,12 +135,18 @@ def test_create_smartnic_vms_per_site(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="smart_nic.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"Smart NIC attachment failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_e_create_smart_nic_vms.py
+++ b/tests/acceptance/test_e_create_smart_nic_vms.py
@@ -98,7 +98,7 @@ def test_create_smartnic_vms_per_site(fablib):
             except Exception as e:
                 print(f"[{key}] Slice submission error: {e}")
                 traceback.print_exc()
-                results[site_name] = {
+                results[key] = {
                     "state": False,
                     "error": error_message(slice_obj=slice_obj, exception=e),
                     "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
@@ -121,14 +121,14 @@ def test_create_smartnic_vms_per_site(fablib):
             if nic_count < 2:
                 raise Exception(f"[{key}] Expected >=2 NIC entries, found {nic_count}")
 
-            results[site_name] = {
+            results[key] = {
                 "state": True,
                 "error": ""
             }
         except Exception as e:
             print(f"[{key}] Smart NIC validation error: {e}")
             traceback.print_exc()
-            results[site_name] = {
+            results[key] = {
                 "state": False,
                 "error": error_message(slice_obj=slice_obj, exception=e),
                 "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
@@ -136,14 +136,14 @@ def test_create_smartnic_vms_per_site(fablib):
 
     print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
-    for site_name, slice_obj in slice_objects.items():
-        site_info = results.get(site_name, {})
+    for key, slice_obj in slice_objects.items():
+        site_info = results.get(key, {})
         if site_info.get("state", False):
-            print(f"{site_name}: PASS")
+            print(f"{key}: PASS")
             delete_slice(slice_obj)
         else:
-            print(f"{site_name}: {site_info.get('error')}")
-            print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+            print(f"{key}: {site_info.get('error')}")
+            print(f"[{key}] Skipping deletion because slice failed. Please inspect manually.")
 
     save_results_json(results, filename="smart_nic.json")
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_e_create_smart_nic_vms.py
+++ b/tests/acceptance/test_e_create_smart_nic_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -103,12 +103,9 @@ def test_create_smartnic_vms_per_site(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
     for key, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
-            slice_obj.post_boot_config()
-
             node = slice_obj.get_node("smartnic-node")
 
             print(f"[{key}] Checking Smart NIC devices via lspci...")

--- a/tests/acceptance/test_f_create_storage_vms.py
+++ b/tests/acceptance/test_f_create_storage_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -123,7 +123,8 @@ def test_attached_storage_parallel(fablib):
             # Verify write
             node.execute("sudo dd if=/dev/zero of=/mnt/fabric_storage/zero-file bs=1024 count=1024")
             stdout, _ = node.execute("ls -lh /mnt/fabric_storage")
-            assert "zero-file" in stdout, f"[{site_name}] Write verification failed"
+            if "zero-file" not in stdout:
+                raise Exception(f"[{site_name}] Write verification failed")
 
             results[site_name] = {
                 "state": True,
@@ -137,12 +138,18 @@ def test_attached_storage_parallel(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="persistent_storage.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"Attached storage test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_f_create_storage_vms.py
+++ b/tests/acceptance/test_f_create_storage_vms.py
@@ -96,7 +96,8 @@ def test_attached_storage_parallel(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -133,7 +134,8 @@ def test_attached_storage_parallel(fablib):
             traceback.print_exc()
             results[site_name] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_f_create_storage_vms.py
+++ b/tests/acceptance/test_f_create_storage_vms.py
@@ -143,6 +143,7 @@ def test_attached_storage_parallel(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -151,5 +152,6 @@ def test_attached_storage_parallel(fablib):
     save_results_json(results, filename="persistent_storage.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"Attached storage test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_f_create_storage_vms.py
+++ b/tests/acceptance/test_f_create_storage_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -99,12 +99,10 @@ def test_attached_storage_parallel(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
+
     for site_name, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
-            slice_obj.post_boot_config()
-
             node = slice_obj.get_node("storage-node")
             storage = node.get_storage(STORAGE_NAME)
             device = storage.get_device_name()

--- a/tests/acceptance/test_g_fabnetv4_shared_nic.py
+++ b/tests/acceptance/test_g_fabnetv4_shared_nic.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
-from tests.utils import error_message, save_results_json, make_site_pairs
+from tests.utils import error_message, save_results_json, make_site_pairs, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -110,12 +110,11 @@ def test_fabnetv4_sharednic_ping(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
+
     for site_name, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
-
             node1 = slice_obj.get_node("node1")
             net1 = slice_obj.get_network("fabnetv4-net1")
 
@@ -142,29 +141,36 @@ def test_fabnetv4_sharednic_ping(fablib):
     for src, dst in site_pairs:
         if src == dst:
             continue  # Skip same-slice tests
-
-        slice_objects[src].post_boot_config()
-        slice_objects[dst].post_boot_config()
-
-        src_node = slice_objects[src].get_node("node1")
-        dst_node = slice_objects[dst].get_node("node1")
-        dst_iface = dst_node.get_interface(network_name="fabnetv4-net1")
-        dst_ip = dst_iface.get_ip_addr()
         pair_key = f"{src}->{dst}"
-
         print(f"Testing {pair_key}...")
 
-        ping_out, _ = src_node.execute(f"ping -c 5 {dst_ip}")
-        if "0% packet loss" in ping_out:
-            pair_result = {"state": True,
-                           "error": ""}
-        else:
-            pair_result = {"state": False,
-                           "error": "Ping Failed"}
-            slices_to_keep.append(src)
-            slices_to_keep.append(dst)
+        try:
+            slice_objects[src].post_boot_config()
+            slice_objects[dst].post_boot_config()
 
-        ping_results[pair_key] = pair_result
+            src_node = slice_objects[src].get_node("node1")
+            dst_node = slice_objects[dst].get_node("node1")
+            dst_iface = dst_node.get_interface(network_name="fabnetv4-net1")
+            dst_ip = dst_iface.get_ip_addr()
+
+            ping_out, _ = src_node.execute(f"ping -c 5 {dst_ip}")
+            if "0% packet loss" in ping_out:
+                pair_result = {"state": True,
+                               "error": ""}
+            else:
+                pair_result = {"state": False,
+                               "error": "Ping Failed"}
+                slices_to_keep.append(src)
+                slices_to_keep.append(dst)
+
+            ping_results[pair_key] = pair_result
+        except Exception as e:
+            print(f"[{pair_key}] FabNetv4 Ping test failed: {e}")
+            traceback.print_exc()
+            ping_results[pair_key] = {
+                "state": False,
+                "error": error_message(slice_obj=slice_obj, exception=e)
+            }
 
     print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices

--- a/tests/acceptance/test_g_fabnetv4_shared_nic.py
+++ b/tests/acceptance/test_g_fabnetv4_shared_nic.py
@@ -107,7 +107,8 @@ def test_fabnetv4_sharednic_ping(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -128,11 +129,12 @@ def test_fabnetv4_sharednic_ping(fablib):
                 "error": ""
             }
         except Exception as e:
-            print(f"[{site_name}] FABNetv4 ping test failed: {e}")
+            print(f"[{site_name}] FABNetv4 configure failed: {e}")
             traceback.print_exc()
             results[site_name] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     slices_to_keep = []
@@ -159,7 +161,10 @@ def test_fabnetv4_sharednic_ping(fablib):
                                "error": ""}
             else:
                 pair_result = {"state": False,
-                               "error": "Ping Failed"}
+                               "error": "Ping Failed",
+                               "src": f"{slice_objects[src].get_name()}/{slice_objects[src].get_slice_id()}",
+                               "dst": f"{slice_objects[dst].get_name()}/{slice_objects[dst].get_slice_id()}",
+                               }
                 slices_to_keep.append(src)
                 slices_to_keep.append(dst)
 
@@ -169,7 +174,9 @@ def test_fabnetv4_sharednic_ping(fablib):
             traceback.print_exc()
             ping_results[pair_key] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "src": f"{slice_objects[src].get_name()}/{slice_objects[src].get_slice_id()}",
+                "dst": f"{slice_objects[dst].get_name()}/{slice_objects[dst].get_slice_id()}",
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_g_fabnetv4_shared_nic.py
+++ b/tests/acceptance/test_g_fabnetv4_shared_nic.py
@@ -22,12 +22,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
-from itertools import combinations
-import random
 import pytest
 import traceback
 import time
-from ipaddress import IPv4Network
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -40,7 +37,6 @@ NIC_MODEL = 'NIC_Basic'
 NIC_CAPACITY_FIELD = 'nic_basic_capacity'
 NETWORK_TYPE = 'IPv4'
 MAX_PARALLEL = 2  # FABNetv4 provisioning can be slow
-SUBNET = IPv4Network("192.168.100.0/24")
 
 
 @pytest.fixture(scope="module")
@@ -64,24 +60,18 @@ def get_sites_with_workers(fablib) -> list[str]:
     return result
 
 
-def create_fabnetv4_sharednic_slice(site1, site2):
+def create_fabnetv4_sharednic_slice(site):
     with fim_lock:
         fablib = FablibManager(fabric_rc=fabric_rc)
-        slice_name = f"test-g-324-fabnetv4-{site1.lower()}-{site2.lower()}-{int(time.time())}"
-        print(f"[{site1}/{site2}] Creating FABNetv4 slice: {slice_name}")
+        slice_name = f"test-g-324-fabnetv4-{site.lower()}-{int(time.time())}"
+        print(f"[{site}] Creating FABNetv4 slice: {slice_name}")
 
         slice_obj = fablib.new_slice(name=slice_name)
 
-        node1 = slice_obj.add_node(name="node1", site=site1)
+        node1 = slice_obj.add_node(name="node1", site=site)
         iface1 = node1.add_component(model=NIC_MODEL, name="nic1").get_interfaces()[0]
         iface1.set_mode("auto")
-
-        node2 = slice_obj.add_node(name="node2", site=site2)
-        iface2 = node2.add_component(model=NIC_MODEL, name="nic2").get_interfaces()[0]
-        iface2.set_mode("auto")
-
         net1 = slice_obj.add_l3network(name="fabnetv4-net1", interfaces=[iface1], type=NETWORK_TYPE)
-        net2 = slice_obj.add_l3network(name="fabnetv4-net2", interfaces=[iface2], type=NETWORK_TYPE)
 
         slice_obj.submit(wait=False)
         return slice_obj
@@ -99,87 +89,101 @@ def test_fabnetv4_sharednic_ping(fablib):
     results = {}
     slice_objects = {}
 
-    site_pairs = make_site_pairs(get_sites_with_workers(fablib))
+    site_names = get_sites_with_workers(fablib)
 
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL) as executor:
         future_to_pair = {
-            executor.submit(create_fabnetv4_sharednic_slice, site1, site2): (site1, site2)
-            for site1, site2 in site_pairs
+            executor.submit(create_fabnetv4_sharednic_slice, site): site
+            for site in site_names
         }
 
         for future in as_completed(future_to_pair):
-            site1, site2 = future_to_pair[future]
-            key = f"{site1}-{site2}"
+            site_name = future_to_pair[future]
             try:
                 slice_obj = future.result()
-                slice_objects[key] = slice_obj
+                slice_objects[site_name] = slice_obj
             except Exception as e:
-                print(f"[{key}] Slice creation failed: {e}")
+                print(f"[{site_name}] Slice creation failed: {e}")
                 traceback.print_exc()
-                results[key] = {
+                results[site_name] = {
                     "state": False,
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
-    for key, slice_obj in slice_objects.items():
+    for site_name, slice_obj in slice_objects.items():
         try:
             slice_obj.wait(progress=False)
             slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
 
             node1 = slice_obj.get_node("node1")
-            node2 = slice_obj.get_node("node2")
             net1 = slice_obj.get_network("fabnetv4-net1")
-            net2 = slice_obj.get_network("fabnetv4-net2")
 
             node1.ip_route_add(
                     subnet=fablib.FABNETV4_SUBNET,
                     gateway=net1.get_gateway(),
             )
-            node2.ip_route_add(
-                subnet=fablib.FABNETV4_SUBNET,
-                gateway=net2.get_gateway(),
-            )
 
-            iface1 = node1.get_interface(network_name="fabnetv4-net1")
-            iface2 = node2.get_interface(network_name="fabnetv4-net2")
-
-            ip1 = iface1.get_ip_addr()
-            ip2 = iface2.get_ip_addr()
-
-            node1.execute(f"ip addr show {iface1.get_os_interface()}")
-            node2.execute(f"ip addr show {iface2.get_os_interface()}")
-
-            ping_out1, _ = node1.execute(f"ping -c 5 {ip2}")
-            ping_out2, _ = node2.execute(f"ping -c 5 {ip1}")
-
-            if "0% packet loss" not in ping_out1 or "0% packet loss" not in ping_out2:
-                raise Exception("Failed to pass traffic!")
-
-            results[key] = {
+            results[site_name] = {
                 "state": True,
                 "error": ""
             }
         except Exception as e:
-            print(f"[{key}] FABNetv4 ping test failed: {e}")
+            print(f"[{site_name}] FABNetv4 ping test failed: {e}")
             traceback.print_exc()
-            results[key] = {
+            results[site_name] = {
                 "state": False,
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
+
+    slices_to_keep = []
+    ping_results = {}
+    site_pairs = make_site_pairs(site_names)
+    for src, dst in site_pairs:
+        if src == dst:
+            continue  # Skip same-slice tests
+
+        slice_objects[src].post_boot_config()
+        slice_objects[dst].post_boot_config()
+
+        src_node = slice_objects[src].get_node("node1")
+        dst_node = slice_objects[dst].get_node("node1")
+        dst_iface = dst_node.get_interface(network_name="fabnetv4-net1")
+        dst_ip = dst_iface.get_ip_addr()
+        pair_key = f"{src}->{dst}"
+
+        print(f"Testing {pair_key}...")
+
+        ping_out, _ = src_node.execute(f"ping -c 5 {dst_ip}")
+        if "0% packet loss" in ping_out:
+            pair_result = {"state": True,
+                           "error": ""}
+        else:
+            pair_result = {"state": False,
+                           "error": "Ping Failed"}
+            slices_to_keep.append(src)
+            slices_to_keep.append(dst)
+
+        ping_results[pair_key] = pair_result
 
     print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
-            print(f"{site_name}: PASS")
+            print(f"{site_name}: Create PASS")
+            if site_name in slice_objects:
+                continue
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
 
+    for key, info in ping_results.items():
+        print(f"{key}: {info}")
+
     save_results_json(results, filename="fabnetv4_shared.json")
+    save_results_json(ping_results, filename="fabnetv4_shared_ping.json")
     print("TEST SUMMARY==========================================================================================")
 
     #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]

--- a/tests/acceptance/test_g_fabnetv4_shared_nic.py
+++ b/tests/acceptance/test_g_fabnetv4_shared_nic.py
@@ -32,7 +32,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -184,12 +184,18 @@ def test_fabnetv4_sharednic_ping(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="fabnetv4_shared.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"FABNetv4 Shared NIC test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_g_fabnetv4_shared_nic.py
+++ b/tests/acceptance/test_g_fabnetv4_shared_nic.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
 from itertools import combinations
-
+import random
 import pytest
 import traceback
 import time
@@ -32,7 +32,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, make_site_pairs
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -50,7 +50,7 @@ def fablib():
     return fablib
 
 
-def get_sites_with_workers(fablib):
+def get_sites_with_workers(fablib) -> list[str]:
     """Return sites with >=1 NIC and workers."""
     result = []
     for site in fablib.list_sites(output="list"):
@@ -60,26 +60,11 @@ def get_sites_with_workers(fablib):
             continue
         hosts = site.get("hosts", 0)
         if hosts >= 1:
-            workers = []
-            for i in range(1, hosts):
-                workers.append(f"{site['name'].lower()}-w{i}.fabric-testbed.net")
-            result.append((site["name"], sorted(workers)))
+            result.append(site["name"])
     return result
 
 
-def make_site_pairs(sites):
-    """
-    Return unique (site1, site2, worker1, worker2) pairs where each site has at least one worker.
-    Avoids (a, a) and symmetric duplicates (a, b) / (b, a).
-    """
-    pairs = []
-    for (site1, workers1), (site2, workers2) in combinations(sites, 2):
-        if workers1 and workers2:
-            pairs.append((site1, site2, workers1[0], workers2[0]))
-    return pairs
-
-
-def create_fabnetv4_sharednic_slice(site1, site2, w1, w2):
+def create_fabnetv4_sharednic_slice(site1, site2):
     with fim_lock:
         fablib = FablibManager(fabric_rc=fabric_rc)
         slice_name = f"test-g-324-fabnetv4-{site1.lower()}-{site2.lower()}-{int(time.time())}"
@@ -87,11 +72,11 @@ def create_fabnetv4_sharednic_slice(site1, site2, w1, w2):
 
         slice_obj = fablib.new_slice(name=slice_name)
 
-        node1 = slice_obj.add_node(name="node1", site=site1, host=w1)
+        node1 = slice_obj.add_node(name="node1", site=site1)
         iface1 = node1.add_component(model=NIC_MODEL, name="nic1").get_interfaces()[0]
         iface1.set_mode("auto")
 
-        node2 = slice_obj.add_node(name="node2", site=site2, host=w2)
+        node2 = slice_obj.add_node(name="node2", site=site2)
         iface2 = node2.add_component(model=NIC_MODEL, name="nic2").get_interfaces()[0]
         iface2.set_mode("auto")
 
@@ -113,14 +98,13 @@ def delete_slice(slice_obj):
 def test_fabnetv4_sharednic_ping(fablib):
     results = {}
     slice_objects = {}
-    available_ips = list(SUBNET)[1:]
 
     site_pairs = make_site_pairs(get_sites_with_workers(fablib))
 
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL) as executor:
         future_to_pair = {
-            executor.submit(create_fabnetv4_sharednic_slice, site1, site2, w1, w2): (site1, site2)
-            for site1, site2, w1, w2 in site_pairs
+            executor.submit(create_fabnetv4_sharednic_slice, site1, site2): (site1, site2)
+            for site1, site2 in site_pairs
         }
 
         for future in as_completed(future_to_pair):

--- a/tests/acceptance/test_g_fabnetv4_shared_nic.py
+++ b/tests/acceptance/test_g_fabnetv4_shared_nic.py
@@ -189,6 +189,7 @@ def test_fabnetv4_sharednic_ping(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -197,5 +198,6 @@ def test_fabnetv4_sharednic_ping(fablib):
     save_results_json(results, filename="fabnetv4_shared.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"FABNetv4 Shared NIC test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_h_fabnetv6_shared_nic.py
+++ b/tests/acceptance/test_h_fabnetv6_shared_nic.py
@@ -128,7 +128,7 @@ def test_fabnetv6_sharednic_ping(fablib):
                 "error": ""
             }
         except Exception as e:
-            print(f"[{site_name}] FABNetv6 ping test failed: {e}")
+            print(f"[{site_name}] FABNetv6 configure failed: {e}")
             traceback.print_exc()
             results[site_name] = {
                 "state": False,
@@ -159,7 +159,10 @@ def test_fabnetv6_sharednic_ping(fablib):
                                "error": ""}
             else:
                 pair_result = {"state": False,
-                               "error": "Ping Failed"}
+                               "error": "Ping Failed",
+                               "src": f"{slice_objects[src].get_name()}/{slice_objects[src].get_slice_id()}",
+                               "dst": f"{slice_objects[dst].get_name()}/{slice_objects[dst].get_slice_id()}",
+                               }
                 slices_to_keep.append(src)
                 slices_to_keep.append(dst)
 
@@ -169,7 +172,9 @@ def test_fabnetv6_sharednic_ping(fablib):
             traceback.print_exc()
             ping_results[pair_key] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "src": f"{slice_objects[src].get_name()}/{slice_objects[src].get_slice_id()}",
+                "dst": f"{slice_objects[dst].get_name()}/{slice_objects[dst].get_slice_id()}",
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_h_fabnetv6_shared_nic.py
+++ b/tests/acceptance/test_h_fabnetv6_shared_nic.py
@@ -188,6 +188,7 @@ def test_fabnetv6_sharednic_ping(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -196,5 +197,6 @@ def test_fabnetv6_sharednic_ping(fablib):
     save_results_json(results, filename="fabnetv6_shared.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"FABNetv6 Shared NIC test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_h_fabnetv6_shared_nic.py
+++ b/tests/acceptance/test_h_fabnetv6_shared_nic.py
@@ -22,15 +22,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
-import random
-from itertools import combinations
-
 import pytest
 import traceback
 import time
-from ipaddress import IPv6Network
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
 
 from tests.utils import error_message, save_results_json, make_site_pairs
 from tests.base_test import fabric_rc, fim_lock
@@ -39,8 +36,7 @@ from tests.base_test import fabric_rc, fim_lock
 NIC_MODEL = 'NIC_Basic'
 NIC_CAPACITY_FIELD = 'nic_basic_capacity'
 NETWORK_TYPE = 'IPv6'
-MAX_PARALLEL = 2  # Limit concurrency
-SUBNET = IPv6Network("2001:db8:abcd:0012::/64")
+MAX_PARALLEL = 2  # FABNetv6 provisioning can be slow
 
 
 @pytest.fixture(scope="module")
@@ -64,24 +60,18 @@ def get_sites_with_workers(fablib) -> list[str]:
     return result
 
 
-def create_fabnetv6_sharednic_slice(site1, site2):
+def create_fabnetv6_sharednic_slice(site):
     with fim_lock:
         fablib = FablibManager(fabric_rc=fabric_rc)
-        slice_name = f"test-h-325-fabnetv6-{site1.lower()}-{site2.lower()}-{int(time.time())}"
-        print(f"[{site1}/{site2}] Creating FABNetv6 slice: {slice_name}")
+        slice_name = f"test-g-324-fabnetv6-{site.lower()}-{int(time.time())}"
+        print(f"[{site}] Creating FABNetv6 slice: {slice_name}")
 
         slice_obj = fablib.new_slice(name=slice_name)
 
-        node1 = slice_obj.add_node(name="node1", site=site1)
+        node1 = slice_obj.add_node(name="node1", site=site)
         iface1 = node1.add_component(model=NIC_MODEL, name="nic1").get_interfaces()[0]
         iface1.set_mode("auto")
-
-        node2 = slice_obj.add_node(name="node2", site=site2)
-        iface2 = node2.add_component(model=NIC_MODEL, name="nic2").get_interfaces()[0]
-        iface2.set_mode("auto")
-
         net1 = slice_obj.add_l3network(name="fabnetv6-net1", interfaces=[iface1], type=NETWORK_TYPE)
-        net2 = slice_obj.add_l3network(name="fabnetv6-net2", interfaces=[iface2], type=NETWORK_TYPE)
 
         slice_obj.submit(wait=False)
         return slice_obj
@@ -99,88 +89,101 @@ def test_fabnetv6_sharednic_ping(fablib):
     results = {}
     slice_objects = {}
 
-    site_pairs = make_site_pairs(get_sites_with_workers(fablib))
+    site_names = get_sites_with_workers(fablib)
 
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL) as executor:
         future_to_pair = {
-            executor.submit(create_fabnetv6_sharednic_slice, site1, site2): (site1, site2)
-            for site1, site2 in site_pairs
+            executor.submit(create_fabnetv6_sharednic_slice, site): site
+            for site in site_names
         }
 
         for future in as_completed(future_to_pair):
-            site1, site2 = future_to_pair[future]
-            key = f"{site1}-{site2}"
+            site_name = future_to_pair[future]
             try:
                 slice_obj = future.result()
-                slice_objects[key] = slice_obj
+                slice_objects[site_name] = slice_obj
             except Exception as e:
-                print(f"[{key}] Slice creation failed: {e}")
+                print(f"[{site_name}] Slice creation failed: {e}")
                 traceback.print_exc()
-                results[key] = {
+                results[site_name] = {
                     "state": False,
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
-    for key, slice_obj in slice_objects.items():
+    for site_name, slice_obj in slice_objects.items():
         try:
             slice_obj.wait(progress=False)
             slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
 
             node1 = slice_obj.get_node("node1")
-            node2 = slice_obj.get_node("node2")
-
             net1 = slice_obj.get_network("fabnetv6-net1")
-            net2 = slice_obj.get_network("fabnetv6-net2")
 
             node1.ip_route_add(
-                    subnet=fablib.FABNETV6_SUBNET,
+                    subnet=fablib.FABNETV4_SUBNET,
                     gateway=net1.get_gateway(),
             )
-            node2.ip_route_add(
-                subnet=fablib.FABNETV6_SUBNET,
-                gateway=net2.get_gateway(),
-            )
 
-            iface1 = node1.get_interface(network_name="fabnetv6-net1")
-            iface2 = node2.get_interface(network_name="fabnetv6-net2")
-
-            node1.execute(f"ip -6 addr show {iface1.get_os_interface()}")
-            node2.execute(f"ip -6 addr show {iface2.get_os_interface()}")
-
-            ip1 = iface1.get_ip_addr()
-            ip2 = iface2.get_ip_addr()
-
-            ping_out1, _ = node1.execute(f"ping6 -c 5 {ip2}")
-            ping_out2, _ = node2.execute(f"ping6 -c 5 {ip1}")
-
-            if "0% packet loss" not in ping_out1 or "0% packet loss" not in ping_out2:
-                raise Exception("Failed to pass traffic!")
-
-            results[key] = {
+            results[site_name] = {
                 "state": True,
                 "error": ""
             }
         except Exception as e:
-            print(f"[{key}] FABNetv6 ping test failed: {e}")
+            print(f"[{site_name}] FABNetv6 ping test failed: {e}")
             traceback.print_exc()
-            results[key] = {
+            results[site_name] = {
                 "state": False,
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
+
+    slices_to_keep = []
+    ping_results = {}
+    site_pairs = make_site_pairs(site_names)
+    for src, dst in site_pairs:
+        if src == dst:
+            continue  # Skip same-slice tests
+
+        slice_objects[src].post_boot_config()
+        slice_objects[dst].post_boot_config()
+
+        src_node = slice_objects[src].get_node("node1")
+        dst_node = slice_objects[dst].get_node("node1")
+        dst_iface = dst_node.get_interface(network_name="fabnetv6-net1")
+        dst_ip = dst_iface.get_ip_addr()
+        pair_key = f"{src}->{dst}"
+
+        print(f"Testing {pair_key}...")
+
+        ping_out, _ = src_node.execute(f"ping6 -c 5 {dst_ip}")
+        if "0% packet loss" in ping_out:
+            pair_result = {"state": True,
+                           "error": ""}
+        else:
+            pair_result = {"state": False,
+                           "error": "Ping Failed"}
+            slices_to_keep.append(src)
+            slices_to_keep.append(dst)
+
+        ping_results[pair_key] = pair_result
 
     print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
-            print(f"{site_name}: PASS")
+            print(f"{site_name}: Create PASS")
+            if site_name in slice_objects:
+                continue
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
 
+    for key, info in ping_results.items():
+        print(f"{key}: {info}")
+
     save_results_json(results, filename="fabnetv6_shared.json")
+    save_results_json(ping_results, filename="fabnetv6_shared_ping.json")
     print("TEST SUMMARY==========================================================================================")
 
     #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]

--- a/tests/acceptance/test_h_fabnetv6_shared_nic.py
+++ b/tests/acceptance/test_h_fabnetv6_shared_nic.py
@@ -31,7 +31,7 @@ from ipaddress import IPv6Network
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -183,12 +183,18 @@ def test_fabnetv6_sharednic_ping(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="fabnetv6_shared.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"FABNetv6 Shared NIC test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_h_fabnetv6_shared_nic.py
+++ b/tests/acceptance/test_h_fabnetv6_shared_nic.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
-from tests.utils import error_message, save_results_json, make_site_pairs
+from tests.utils import error_message, save_results_json, make_site_pairs, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -110,10 +110,9 @@ def test_fabnetv6_sharednic_ping(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
     for site_name, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
 
             node1 = slice_obj.get_node("node1")
@@ -142,29 +141,36 @@ def test_fabnetv6_sharednic_ping(fablib):
     for src, dst in site_pairs:
         if src == dst:
             continue  # Skip same-slice tests
-
-        slice_objects[src].post_boot_config()
-        slice_objects[dst].post_boot_config()
-
-        src_node = slice_objects[src].get_node("node1")
-        dst_node = slice_objects[dst].get_node("node1")
-        dst_iface = dst_node.get_interface(network_name="fabnetv6-net1")
-        dst_ip = dst_iface.get_ip_addr()
         pair_key = f"{src}->{dst}"
-
         print(f"Testing {pair_key}...")
 
-        ping_out, _ = src_node.execute(f"ping6 -c 5 {dst_ip}")
-        if "0% packet loss" in ping_out:
-            pair_result = {"state": True,
-                           "error": ""}
-        else:
-            pair_result = {"state": False,
-                           "error": "Ping Failed"}
-            slices_to_keep.append(src)
-            slices_to_keep.append(dst)
+        try:
+            slice_objects[src].post_boot_config()
+            slice_objects[dst].post_boot_config()
 
-        ping_results[pair_key] = pair_result
+            src_node = slice_objects[src].get_node("node1")
+            dst_node = slice_objects[dst].get_node("node1")
+            dst_iface = dst_node.get_interface(network_name="fabnetv6-net1")
+            dst_ip = dst_iface.get_ip_addr()
+
+            ping_out, _ = src_node.execute(f"ping6 -c 5 {dst_ip}")
+            if "0% packet loss" in ping_out:
+                pair_result = {"state": True,
+                               "error": ""}
+            else:
+                pair_result = {"state": False,
+                               "error": "Ping Failed"}
+                slices_to_keep.append(src)
+                slices_to_keep.append(dst)
+
+            ping_results[pair_key] = pair_result
+        except Exception as e:
+            print(f"[{pair_key}] FabNetv6 Ping test failed: {e}")
+            traceback.print_exc()
+            ping_results[pair_key] = {
+                "state": False,
+                "error": error_message(slice_obj=slice_obj, exception=e)
+            }
 
     print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices

--- a/tests/acceptance/test_h_fabnetv6_shared_nic.py
+++ b/tests/acceptance/test_h_fabnetv6_shared_nic.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
+import random
 from itertools import combinations
 
 import pytest
@@ -31,7 +32,7 @@ from ipaddress import IPv6Network
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, make_site_pairs
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -49,7 +50,7 @@ def fablib():
     return fablib
 
 
-def get_sites_with_workers(fablib):
+def get_sites_with_workers(fablib) -> list[str]:
     """Return sites with >=1 NIC and workers."""
     result = []
     for site in fablib.list_sites(output="list"):
@@ -59,26 +60,11 @@ def get_sites_with_workers(fablib):
             continue
         hosts = site.get("hosts", 0)
         if hosts >= 1:
-            workers = []
-            for i in range(1, hosts):
-                workers.append(f"{site['name'].lower()}-w{i}.fabric-testbed.net")
-            result.append((site["name"], sorted(workers)))
+            result.append(site["name"])
     return result
 
 
-def make_site_pairs(sites):
-    """
-    Return unique (site1, site2, worker1, worker2) pairs where each site has at least one worker.
-    Avoids (a, a) and symmetric duplicates (a, b) / (b, a).
-    """
-    pairs = []
-    for (site1, workers1), (site2, workers2) in combinations(sites, 2):
-        if workers1 and workers2:
-            pairs.append((site1, site2, workers1[0], workers2[0]))
-    return pairs
-
-
-def create_fabnetv6_sharednic_slice(site1, site2, w1, w2):
+def create_fabnetv6_sharednic_slice(site1, site2):
     with fim_lock:
         fablib = FablibManager(fabric_rc=fabric_rc)
         slice_name = f"test-h-325-fabnetv6-{site1.lower()}-{site2.lower()}-{int(time.time())}"
@@ -86,11 +72,11 @@ def create_fabnetv6_sharednic_slice(site1, site2, w1, w2):
 
         slice_obj = fablib.new_slice(name=slice_name)
 
-        node1 = slice_obj.add_node(name="node1", site=site1, host=w1)
+        node1 = slice_obj.add_node(name="node1", site=site1)
         iface1 = node1.add_component(model=NIC_MODEL, name="nic1").get_interfaces()[0]
         iface1.set_mode("auto")
 
-        node2 = slice_obj.add_node(name="node2", site=site2, host=w2)
+        node2 = slice_obj.add_node(name="node2", site=site2)
         iface2 = node2.add_component(model=NIC_MODEL, name="nic2").get_interfaces()[0]
         iface2.set_mode("auto")
 
@@ -117,8 +103,8 @@ def test_fabnetv6_sharednic_ping(fablib):
 
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL) as executor:
         future_to_pair = {
-            executor.submit(create_fabnetv6_sharednic_slice, site1, site2, w1, w2): (site1, site2)
-            for site1, site2, w1, w2 in site_pairs
+            executor.submit(create_fabnetv6_sharednic_slice, site1, site2): (site1, site2)
+            for site1, site2 in site_pairs
         }
 
         for future in as_completed(future_to_pair):

--- a/tests/acceptance/test_i_l2bridge_shared_nic.py
+++ b/tests/acceptance/test_i_l2bridge_shared_nic.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -133,7 +133,9 @@ def test_sharednic_local_bridge_reachability(fablib):
 
             # Test ping
             stdout, stderr = node1.execute(f"ping -c 5 {ip2}")
-            assert "0% packet loss" in stdout, f"[{site_name}] Ping failed between nodes"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{site_name}] Ping failed between nodes")
+
             results[site_name] = {
                 "state": True,
                 "error": ""
@@ -147,12 +149,18 @@ def test_sharednic_local_bridge_reachability(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="l2bridge_shared.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"Local bridge test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_i_l2bridge_shared_nic.py
+++ b/tests/acceptance/test_i_l2bridge_shared_nic.py
@@ -154,6 +154,7 @@ def test_sharednic_local_bridge_reachability(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -162,5 +163,6 @@ def test_sharednic_local_bridge_reachability(fablib):
     save_results_json(results, filename="l2bridge_shared.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"Local bridge test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_i_l2bridge_shared_nic.py
+++ b/tests/acceptance/test_i_l2bridge_shared_nic.py
@@ -49,7 +49,8 @@ def fablib():
 
 
 def get_active_sites(fablib):
-    return [site for site in fablib.list_sites(output="list") if site.get("state") == "Active"]
+    return [site for site in fablib.list_sites(output="list") if site.get("state") == "Active" and
+            "EDC" not in site.get("name")]
 
 
 def create_local_bridge_sharednic_slice(site):

--- a/tests/acceptance/test_i_l2bridge_shared_nic.py
+++ b/tests/acceptance/test_i_l2bridge_shared_nic.py
@@ -111,7 +111,8 @@ def test_sharednic_local_bridge_reachability(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -145,7 +146,8 @@ def test_sharednic_local_bridge_reachability(fablib):
             traceback.print_exc()
             results[site_name] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_i_l2bridge_shared_nic.py
+++ b/tests/acceptance/test_i_l2bridge_shared_nic.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -114,12 +114,11 @@ def test_sharednic_local_bridge_reachability(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
+
     for site_name, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
-
             node1 = slice_obj.get_node("node1")
             node2 = slice_obj.get_node("node2")
 

--- a/tests/acceptance/test_j_l2bridge_smart_nic.py
+++ b/tests/acceptance/test_j_l2bridge_smart_nic.py
@@ -48,7 +48,8 @@ def fablib():
 
 
 def get_active_sites(fablib):
-    return [site for site in fablib.list_sites(output="list") if site.get("state") == "Active"]
+    return [site for site in fablib.list_sites(output="list") if site.get("state") == "Active" and
+            site.get("nic_connectx_5_available") > 0 and site.get("nic_connectx_6_available") > 0]
 
 
 def create_smartnic_bridge_slice(site, nic_type1, nic_type2):

--- a/tests/acceptance/test_j_l2bridge_smart_nic.py
+++ b/tests/acceptance/test_j_l2bridge_smart_nic.py
@@ -151,6 +151,7 @@ def test_smartnic_local_bridge_reachability(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -159,5 +160,6 @@ def test_smartnic_local_bridge_reachability(fablib):
     save_results_json(results, filename="l2bridge_smart_nic.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"Smart NIC bridge test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_j_l2bridge_smart_nic.py
+++ b/tests/acceptance/test_j_l2bridge_smart_nic.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -130,7 +130,9 @@ def test_smartnic_local_bridge_reachability(fablib):
 
             # Test reachability
             stdout, stderr = node1.execute(f"ping -c 5 {ip2}")
-            assert "0% packet loss" in stdout, f"[{site_name}] Ping failed"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{site_name}] Ping failed")
+
             results[site_name] = {
                 "state": True,
                 "error": ""
@@ -144,12 +146,18 @@ def test_smartnic_local_bridge_reachability(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="l2bridge_smart_nic.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"Smart NIC bridge test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_j_l2bridge_smart_nic.py
+++ b/tests/acceptance/test_j_l2bridge_smart_nic.py
@@ -29,7 +29,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -112,10 +112,10 @@ def test_smartnic_local_bridge_reachability(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
+
     for site_name, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
 
             node1 = slice_obj.get_node("node1")

--- a/tests/acceptance/test_j_l2bridge_smart_nic.py
+++ b/tests/acceptance/test_j_l2bridge_smart_nic.py
@@ -109,7 +109,8 @@ def test_smartnic_local_bridge_reachability(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -143,7 +144,8 @@ def test_smartnic_local_bridge_reachability(fablib):
             traceback.print_exc()
             results[site_name] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -136,9 +136,6 @@ def test_smartnic_l2ptp_across_sites(fablib):
             node1 = slice_obj.get_node("node1")
             node2 = slice_obj.get_node("node2")
 
-            iface1 = node1.get_interface(network_name=NETWORK_NAME)
-            ip1 = iface1.get_ip_addr()
-
             iface2 = node2.get_interface(network_name=NETWORK_NAME)
             ip2 = iface2.get_ip_addr()
 

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
-from itertools import combinations
 
 import pytest
 import traceback
@@ -31,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -153,7 +152,9 @@ def test_smartnic_l2ptp_across_sites(fablib):
             ip2 = iface2.get_ip_addr()
 
             stdout, _ = node1.execute(f"ping -c 5 {ip2}")
-            assert "0% packet loss" in stdout, f"[{key}] Ping failed"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{key}] Ping failed")
+
             results[key] = {
                 "state": True,
                 "error": ""
@@ -167,12 +168,18 @@ def test_smartnic_l2ptp_across_sites(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
     for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+        site_info = results.get(site_name, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
+            print(f"{site_name}: {site_info.get('error')}")
             print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="l2ptp_smart_nic.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"L2PTP SmartNIC tests failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -173,6 +173,7 @@ def test_smartnic_l2ptp_across_sites(fablib):
     for site_name, slice_obj in slice_objects.items():
         site_info = results.get(site_name, {})
         if site_info.get("state", False):
+            print(f"{site_name}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{site_name}: {site_info.get('error')}")
@@ -181,5 +182,6 @@ def test_smartnic_l2ptp_across_sites(fablib):
     save_results_json(results, filename="l2ptp_smart_nic.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"L2PTP SmartNIC tests failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -105,6 +105,8 @@ def test_smartnic_l2ptp_across_sites(fablib):
         site_names = [site["name"] for site in sites]
         site_pairs = make_site_pairs(site_names)
         for site1, site2 in site_pairs:
+            if site1 == site2:
+                continue
             test_tasks.append((site1, site2, nic_model))
 
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL_TESTS) as executor:

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -30,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.utils import error_message, save_results_json, make_site_pairs
+from tests.utils import error_message, save_results_json, make_site_pairs, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -129,10 +129,10 @@ def test_smartnic_l2ptp_across_sites(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
+
     for key, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
 
             node1 = slice_obj.get_node("node1")

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -30,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, make_site_pairs
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -56,16 +56,6 @@ def get_smartnic_sites(fablib, nic_capacity_field):
         site for site in fablib.list_sites(output="list")
         if site.get("state") == "Active" and site.get(nic_capacity_field, 0) >= 1
     ]
-
-
-def make_site_pairs(site_list):
-    """
-    Return unique non-overlapping (site1_name, site2_name) pairs from site_list.
-    Each site appears at most once across all pairs.
-    """
-    site_names = [site["name"] for site in site_list]
-    num_pairs = len(site_names) // 2
-    return [(site_names[i], site_names[i + 1]) for i in range(0, 2 * num_pairs, 2)]
 
 
 def create_l2ptp_slice(site1, site2, nic_model):
@@ -112,7 +102,8 @@ def test_smartnic_l2ptp_across_sites(fablib):
         if len(sites) < 2:
             print(f"Skipping {nic_model}: Not enough sites with {capacity_field}")
             continue
-        site_pairs = make_site_pairs(sites)
+        site_names = [site["name"] for site in sites]
+        site_pairs = make_site_pairs(site_names)
         for site1, site2 in site_pairs:
             test_tasks.append((site1, site2, nic_model))
 

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -126,7 +126,8 @@ def test_smartnic_l2ptp_across_sites(fablib):
                 traceback.print_exc()
                 results[key] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -155,7 +156,8 @@ def test_smartnic_l2ptp_across_sites(fablib):
             traceback.print_exc()
             results[key] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_l_l2sts_shared_nic.py
+++ b/tests/acceptance/test_l_l2sts_shared_nic.py
@@ -126,7 +126,8 @@ def test_l2sts_sharednic_ping(fablib):
                 traceback.print_exc()
                 results[key] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -170,7 +171,8 @@ def test_l2sts_sharednic_ping(fablib):
             traceback.print_exc()
             results[key] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     # Cleanup only successful slices

--- a/tests/acceptance/test_l_l2sts_shared_nic.py
+++ b/tests/acceptance/test_l_l2sts_shared_nic.py
@@ -112,6 +112,7 @@ def test_l2sts_sharednic_ping(fablib):
         future_to_triplet = {
             executor.submit(create_l2sts_sharednic_slice, site1, site2): (site1, site2)
             for site1, site2 in site_pairs
+            if site1 != site2
         }
 
         for future in as_completed(future_to_triplet):

--- a/tests/acceptance/test_l_l2sts_shared_nic.py
+++ b/tests/acceptance/test_l_l2sts_shared_nic.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
-from itertools import combinations
 
 import pytest
 import traceback
@@ -31,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -161,11 +160,14 @@ def test_l2sts_sharednic_ping(fablib):
             node3.execute(f"ip addr show {iface3.get_os_interface()}")
 
             stdout, _ = node1.execute(f"ping -c 5 {ip2}")
-            assert "0% packet loss" in stdout, f"[{key}] Ping failed"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{key}] Ping failed")
             stdout, _ = node1.execute(f"ping -c 5 {ip3}")
-            assert "0% packet loss" in stdout, f"[{key}] Ping failed"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{key}] Ping failed")
             stdout, _ = node2.execute(f"ping -c 5 {ip3}")
-            assert "0% packet loss" in stdout, f"[{key}] Ping failed"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{key}] Ping failed")
 
             results[key] = {
                 "state": True,
@@ -185,6 +187,19 @@ def test_l2sts_sharednic_ping(fablib):
             delete_slice(slice_obj)
         else:
             print(f"[{key}] Skipping deletion because slice failed. Please inspect manually.")
+
+    print("TEST SUMMARY==========================================================================================")
+    # Cleanup only successful slices
+    for key, slice_obj in slice_objects.items():
+        site_info = results.get(key, {})
+        if site_info.get("state", False):
+            delete_slice(slice_obj)
+        else:
+            print(f"{key}: {site_info.get('error')}")
+            print(f"[{key}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="l2sts_shared.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"L2STS Shared NIC test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_l_l2sts_shared_nic.py
+++ b/tests/acceptance/test_l_l2sts_shared_nic.py
@@ -193,6 +193,7 @@ def test_l2sts_sharednic_ping(fablib):
     for key, slice_obj in slice_objects.items():
         site_info = results.get(key, {})
         if site_info.get("state", False):
+            print(f"{key}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{key}: {site_info.get('error')}")
@@ -201,5 +202,6 @@ def test_l2sts_sharednic_ping(fablib):
     save_results_json(results, filename="l2sts_shared.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"L2STS Shared NIC test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_l_l2sts_shared_nic.py
+++ b/tests/acceptance/test_l_l2sts_shared_nic.py
@@ -30,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, make_site_pairs
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -48,7 +48,7 @@ def fablib():
     return fablib
 
 
-def get_sites_with_workers(fablib):
+def get_sites_with_workers(fablib) -> list[str]:
     """Return sites with >=2 workers and Shared NIC capacity."""
     result = []
     for site in fablib.list_sites(output="list"):
@@ -61,15 +61,6 @@ def get_sites_with_workers(fablib):
             result.append(site["name"])
 
     return result
-
-
-def make_site_pairs(site_names):
-    """
-    Return unique non-overlapping (site1_name, site2_name) pairs from site_list.
-    Each site appears at most once across all pairs.
-    """
-    num_pairs = len(site_names) // 2
-    return [(site_names[i], site_names[i + 1]) for i in range(0, 2 * num_pairs, 2)]
 
 
 def create_l2sts_sharednic_slice(site1, site2):
@@ -114,8 +105,8 @@ def test_l2sts_sharednic_ping(fablib):
     results = {}
     slice_objects = {}
 
-    sites_with_workers = get_sites_with_workers(fablib)
-    site_pairs = make_site_pairs(sites_with_workers)
+    site_names = get_sites_with_workers(fablib)
+    site_pairs = make_site_pairs(site_names)
 
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL) as executor:
         future_to_triplet = {

--- a/tests/acceptance/test_l_l2sts_shared_nic.py
+++ b/tests/acceptance/test_l_l2sts_shared_nic.py
@@ -30,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.utils import error_message, save_results_json, make_site_pairs
+from tests.utils import error_message, save_results_json, make_site_pairs, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -129,10 +129,10 @@ def test_l2sts_sharednic_ping(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
+
     for key, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
 
             node1 = slice_obj.get_node("node1")

--- a/tests/acceptance/test_m_l2sts_smart_nic.py
+++ b/tests/acceptance/test_m_l2sts_smart_nic.py
@@ -120,7 +120,8 @@ def test_l2sts_smartnic_ping(fablib):
                 traceback.print_exc()
                 results[key] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -168,7 +169,8 @@ def test_l2sts_smartnic_ping(fablib):
             traceback.print_exc()
             results[key] = {
                 "state": False,
-                "error": error_message(slice_obj=slice_obj, exception=e)
+                "error": error_message(slice_obj=slice_obj, exception=e),
+                "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
             }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_m_l2sts_smart_nic.py
+++ b/tests/acceptance/test_m_l2sts_smart_nic.py
@@ -30,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.utils import error_message, save_results_json, make_site_pairs
+from tests.utils import error_message, save_results_json, make_site_pairs, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -123,10 +123,10 @@ def test_l2sts_smartnic_ping(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
+
     for key, slice_obj in slice_objects.items():
         try:
-            slice_obj.wait(progress=False)
-            slice_obj.wait_ssh(progress=False)
             slice_obj.post_boot_config()
 
             node1 = slice_obj.get_node("node1")

--- a/tests/acceptance/test_m_l2sts_smart_nic.py
+++ b/tests/acceptance/test_m_l2sts_smart_nic.py
@@ -185,6 +185,7 @@ def test_l2sts_smartnic_ping(fablib):
     for key, slice_obj in slice_objects.items():
         site_info = results.get(key, {})
         if site_info.get("state", False):
+            print(f"{key}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{key}: {site_info.get('error')}")
@@ -193,5 +194,6 @@ def test_l2sts_smartnic_ping(fablib):
     save_results_json(results, filename="l2sts_smart_nic.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"L2STS SmartNIC test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_m_l2sts_smart_nic.py
+++ b/tests/acceptance/test_m_l2sts_smart_nic.py
@@ -106,6 +106,7 @@ def test_l2sts_smartnic_ping(fablib):
         future_to_triplet = {
             executor.submit(create_l2sts_smartnic_slice, site1, site2): (site1, site2)
             for site1, site2, in site_pairs
+            if site1 != site2
         }
 
         for future in as_completed(future_to_triplet):

--- a/tests/acceptance/test_m_l2sts_smart_nic.py
+++ b/tests/acceptance/test_m_l2sts_smart_nic.py
@@ -30,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, make_site_pairs
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -58,16 +58,6 @@ def get_sites_with_smartnic(fablib):
             continue
         result.append(site["name"])
     return result
-
-
-def make_site_pairs(site_list):
-    """
-    Return unique non-overlapping (site1_name, site2_name) pairs from site_list.
-    Each site appears at most once across all pairs.
-    """
-    site_names = [site["name"] for site in site_list]
-    num_pairs = len(site_names) // 2
-    return [(site_names[i], site_names[i + 1]) for i in range(0, 2 * num_pairs, 2)]
 
 
 def create_l2sts_smartnic_slice(site1, site2):
@@ -109,8 +99,8 @@ def test_l2sts_smartnic_ping(fablib):
     results = {}
     slice_objects = {}
 
-    sites_with_workers = get_sites_with_smartnic(fablib)
-    site_pairs = make_site_pairs(sites_with_workers)
+    site_names = get_sites_with_smartnic(fablib)
+    site_pairs = make_site_pairs(site_names)
 
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL) as executor:
         future_to_triplet = {

--- a/tests/acceptance/test_m_l2sts_smart_nic.py
+++ b/tests/acceptance/test_m_l2sts_smart_nic.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
-from itertools import combinations
 
 import pytest
 import traceback
@@ -31,7 +30,7 @@ from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from ipaddress import IPv4Network
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 
@@ -160,11 +159,14 @@ def test_l2sts_smartnic_ping(fablib):
             node3.execute(f"ip addr show {iface3.get_os_interface()}")
 
             stdout, _ = node1.execute(f"ping -c 5 {ip2}")
-            assert "0% packet loss" in stdout, f"[{key}] Ping failed"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{key}] Ping failed")
             stdout, _ = node1.execute(f"ping -c 5 {ip3}")
-            assert "0% packet loss" in stdout, f"[{key}] Ping failed"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{key}] Ping failed")
             stdout, _ = node2.execute(f"ping -c 5 {ip3}")
-            assert "0% packet loss" in stdout, f"[{key}] Ping failed"
+            if "0% packet loss" not in stdout:
+                raise Exception(f"[{key}] Ping failed")
 
             results[key] = {
                 "state": True,
@@ -178,12 +180,18 @@ def test_l2sts_smartnic_ping(fablib):
                 "error": error_message(slice_obj=slice_obj, exception=e)
             }
 
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
-    for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+    for key, slice_obj in slice_objects.items():
+        site_info = results.get(key, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
-            print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+            print(f"{key}: {site_info.get('error')}")
+            print(f"[{key}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="l2sts_smart_nic.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"L2STS SmartNIC test failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_z_create_gpu_vms.py
+++ b/tests/acceptance/test_z_create_gpu_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.utils import error_message, save_results_json
+from tests.utils import error_message, save_results_json, wait_and_configure_slices
 from tests.base_test import fabric_rc, fim_lock
 
 GPU_MODELS = {
@@ -121,11 +121,10 @@ def test_create_gpu_vms_per_site(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
+    wait_and_configure_slices(slice_objects)
+
     # Wait for all slices to complete provisioning
     for site_name_gpu_model, slice_obj in slice_objects.items():
-        slice_obj.wait(progress=False)
-        slice_obj.wait_ssh(progress=False)
-        slice_obj.post_boot_config()
         success = slice_obj.get_state() in ["StableOK", "StableError"]
         results[site_name] = {
             "state": success,

--- a/tests/acceptance/test_z_create_gpu_vms.py
+++ b/tests/acceptance/test_z_create_gpu_vms.py
@@ -176,6 +176,7 @@ def test_create_gpu_vms_per_site(fablib):
     for key, slice_obj in slice_objects.items():
         site_info = results.get(key, {})
         if site_info.get("state", False):
+            print(f"{key}: PASS")
             delete_slice(slice_obj)
         else:
             print(f"{key}: {site_info.get('error')}")
@@ -184,5 +185,6 @@ def test_create_gpu_vms_per_site(fablib):
     save_results_json(results, filename="gpu.json")
     print("TEST SUMMARY==========================================================================================")
 
-    failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    #failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
+    failed = [site for site, info in results.items() if not info["state"]]
     assert not failed, f"Slice with GPUs failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_z_create_gpu_vms.py
+++ b/tests/acceptance/test_z_create_gpu_vms.py
@@ -118,7 +118,8 @@ def test_create_gpu_vms_per_site(fablib):
                 traceback.print_exc()
                 results[site_name_gpu_model] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     wait_and_configure_slices(slice_objects)
@@ -167,7 +168,8 @@ def test_create_gpu_vms_per_site(fablib):
                 print(f"[{site_name_gpu_model}] Validation error: {e}")
                 results[site_name_gpu_model] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": error_message(slice_obj=slice_obj, exception=e),
+                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
                 }
 
     print("TEST SUMMARY==========================================================================================")

--- a/tests/acceptance/test_z_create_gpu_vms.py
+++ b/tests/acceptance/test_z_create_gpu_vms.py
@@ -28,7 +28,7 @@ import time
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from tests.acceptance.utils import error_message
+from tests.utils import error_message, save_results_json
 from tests.base_test import fabric_rc, fim_lock
 
 GPU_MODELS = {
@@ -162,7 +162,8 @@ def test_create_gpu_vms_per_site(fablib):
 
                 print(f"[{slice_name}] Running nvidia-smi...")
                 stdout, stderr = node.execute("nvidia-smi")
-                assert "NVIDIA" in stdout, f"{slice_name} - GPU not detected by nvidia-smi"
+                if "NVIDIA" not in stdout:
+                    raise Exception(f"{slice_name} - GPU not detected by nvidia-smi")
             except Exception as e:
                 print(f"[{site_name_gpu_model}] Validation error: {e}")
                 results[site_name_gpu_model] = {
@@ -170,13 +171,18 @@ def test_create_gpu_vms_per_site(fablib):
                     "error": error_message(slice_obj=slice_obj, exception=e)
                 }
 
-    # Cleanup
+    print("TEST SUMMARY==========================================================================================")
     # Cleanup only successful slices
-    for site_name, slice_obj in slice_objects.items():
-        if results.get(site_name, {}).get("state", False):
+    for key, slice_obj in slice_objects.items():
+        site_info = results.get(key, {})
+        if site_info.get("state", False):
             delete_slice(slice_obj)
         else:
-            print(f"[{site_name}] Skipping deletion because slice failed. Please inspect manually.")
+            print(f"{key}: {site_info.get('error')}")
+            print(f"[{key}] Skipping deletion because slice failed. Please inspect manually.")
+
+    save_results_json(results, filename="gpu.json")
+    print("TEST SUMMARY==========================================================================================")
 
     failed = [f"{site}: {info['error']}" for site, info in results.items() if not info["state"]]
     assert not failed, f"Slice with GPUs failed on: {', '.join(failed)}"

--- a/tests/acceptance/test_z_create_gpu_vms.py
+++ b/tests/acceptance/test_z_create_gpu_vms.py
@@ -136,6 +136,16 @@ def test_create_gpu_vms_per_site(fablib):
             try:
                 node = slice_obj.get_node("gpu-node")
                 slice_name = slice_obj.get_name()
+                print(f"[{slice_name}] Checking GPU via lspci...")
+                cmd = "sudo dnf install -y -q pciutils && lspci | grep -i 'NVIDIA|3D controller'"
+                stdout, stderr = node.execute(cmd)
+                if not('NVIDIA' in stdout and '3D controller' in stdout):
+                    raise Exception("GPU not detected")
+                results[site_name] = {
+                    "state": True,
+                    "error": ""
+                }
+                '''
                 print(f"[{slice_name}] Installing CUDA and checking GPU...")
 
                 setup_cmds = [
@@ -164,6 +174,7 @@ def test_create_gpu_vms_per_site(fablib):
                 stdout, stderr = node.execute("nvidia-smi")
                 if "NVIDIA" not in stdout:
                     raise Exception(f"{slice_name} - GPU not detected by nvidia-smi")
+                '''
             except Exception as e:
                 print(f"[{site_name_gpu_model}] Validation error: {e}")
                 results[site_name_gpu_model] = {

--- a/tests/acceptance/test_z_create_gpu_vms.py
+++ b/tests/acceptance/test_z_create_gpu_vms.py
@@ -142,12 +142,12 @@ def test_create_gpu_vms_per_site(fablib):
                     "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pciutils && lspci | grep 'NVIDIA|3D controller'",
                     "sudo DEBIAN_FRONTEND=noninteractive apt-get -q update",
                     "sudo DEBIAN_FRONTEND=noninteractive apt-get -q install -y linux-headers-$(uname -r) gcc"
-                    'sudo apt-get update -q',
-                    'sudo apt-get install -y linux-headers-$(uname -r) gcc',
+                    'sudo DEBIAN_FRONTEND=noninteractive apt-get update -q',
+                    'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-headers-$(uname -r) gcc',
                     f'wget https://developer.download.nvidia.com/compute/cuda/repos/{distro}/{architecture}/cuda-keyring_1.1-1_all.deb',
                     f'sudo DEBIAN_FRONTEND=noninteractive dpkg -i cuda-keyring_1.1-1_all.deb',
                     f'sudo DEBIAN_FRONTEND=noninteractive apt-get -q update',
-                    f'sudo apt-get -q install -y cuda-{version.replace(".", "-")}'
+                    f'sudo DEBIAN_FRONTEND=noninteractive apt-get -q install -y cuda-{version.replace(".", "-")}'
                 ]
 
                 for cmd in setup_cmds:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -34,7 +34,7 @@ from threading import Lock
 
 fim_lock = Lock()
 
-DEBUG = True
+DEBUG = False
 if not DEBUG:
     fabric_rc = None
     os.environ['FABRIC_AVOID'] = 'EDUKY'

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -34,7 +34,7 @@ from threading import Lock
 
 fim_lock = Lock()
 
-DEBUG = False
+DEBUG = True
 if not DEBUG:
     fabric_rc = None
     os.environ['FABRIC_AVOID'] = 'EDUKY'

--- a/tests/daily/slice_helper.py
+++ b/tests/daily/slice_helper.py
@@ -124,18 +124,6 @@ def create_site_worker_slices(fablib, sites):
     return slices, failed_slices
 
 
-def wait_and_configure_slices(slices):
-    for name, slice_obj in slices.items():
-        print(f"Waiting on slice {name}")
-        try:
-            slice_obj.wait()
-            slice_obj.wait_ssh()
-            slice_obj.post_boot_config()
-        except Exception as e:
-            print(f"[{name}] Slice configuration error: {e}")
-            traceback.print_exc()
-
-
 def get_site_pairs(slices):
     all_pairs = list(combinations(slices.keys(), 2))
     count = len(slices) // 2  # Automatically use half the number of slices

--- a/tests/daily/slice_helper.py
+++ b/tests/daily/slice_helper.py
@@ -22,12 +22,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
-import json
 import os
 import random
 import time
 import traceback
-from itertools import product, combinations
+from itertools import combinations
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 from fabrictestbed_extensions.fablib.slice import Slice
@@ -174,7 +173,3 @@ def cleanup_slices(slices, slices_to_keep):
         except Exception as e:
             print(f"Error deleting slice {name}: {e}")
 
-
-def save_results_json(results, filename="iperf_test_results.json"):
-    with open(filename, "w") as f:
-        json.dump(results, f, indent=2)

--- a/tests/daily/slice_helper.py
+++ b/tests/daily/slice_helper.py
@@ -79,8 +79,8 @@ def create_slice(site, worker):
             try:
                 slice_obj.validate()
             except Exception as e:
-                print(f"Validation failed for {site_name}@{worker}: {e}")
-                return f"{site_name}-{worker}", str(e)
+                print(f"Validation failed for {slice_name}: {e}")
+                return f"{slice_name}", str(e)
 
             print(f"Submitting slice {slice_name}")
             slice_obj.submit(wait=False)
@@ -88,7 +88,7 @@ def create_slice(site, worker):
     except Exception as e:
         print(f"Failed to create slice for {site_name}@{worker}: {e}")
         traceback.print_exc()
-        return f"{site_name}-{worker}", str(e)
+        return f"{slice_name}", str(e)
 
 
 def create_site_worker_slices(fablib, sites):

--- a/tests/daily/slice_helper.py
+++ b/tests/daily/slice_helper.py
@@ -96,12 +96,21 @@ def create_site_worker_slices(fablib, sites):
     failed_slices = {}
 
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL) as executor:
-        futures = {
-            executor.submit(create_slice, site, worker): (site, worker)
-            for site in sites
-            if site["name"] not in avoid
-            for worker in range(1, site["hosts"] + 1)
-        }
+        futures = {}
+        for site in sites:
+            if site.get("name") == "EDUKY":
+                continue
+            if site.get("state") != "Active":
+                continue
+            if site.get("state") in avoid:
+                continue
+            site_obj = fablib.get_resources().get_site(site["name"])
+            for h in site_obj.get_hosts():
+                if h.get_state() != "Active":
+                    continue
+                f = executor.submit(create_slice, site, h)
+                futures[f] = (site, h)
+
         for future in as_completed(futures):
             site_worker = futures[future]
             try:
@@ -154,9 +163,11 @@ def run_remote_command(node, cmd):
         return "", str(e)
 
 
-def cleanup_slices(slices):
+def cleanup_slices(slices, slices_to_keep):
     for name, slice_obj in slices.items():
         try:
+            if slice_obj.get_slice_id() in slices_to_keep:
+                continue
             print(f"Deleting slice {name}")
             slice_obj.delete()
         except Exception as e:

--- a/tests/daily/slice_helper.py
+++ b/tests/daily/slice_helper.py
@@ -105,10 +105,10 @@ def create_site_worker_slices(fablib, sites):
             if site.get("state") in avoid:
                 continue
             site_obj = fablib.get_resources().get_site(site["name"])
-            for h in site_obj.get_hosts():
+            for h in site_obj.get_hosts().values():
                 if h.get_state() != "Active":
                     continue
-                f = executor.submit(create_slice, site, h)
+                f = executor.submit(create_slice, site, h.get_name())
                 futures[f] = (site, h)
 
         for future in as_completed(futures):

--- a/tests/daily/slice_helper.py
+++ b/tests/daily/slice_helper.py
@@ -34,7 +34,7 @@ from fabrictestbed_extensions.fablib.slice import Slice
 
 from tests.base_test import fabric_rc, fim_lock
 
-SLICE_PREFIX = "iperf@"
+SLICE_PREFIX = "iperf"
 DEFAULT_IMAGE = "default_ubuntu_22"
 NIC_MODEL = "NIC_Basic"
 MAX_PARALLEL = 4

--- a/tests/daily/slice_helper.py
+++ b/tests/daily/slice_helper.py
@@ -42,6 +42,7 @@ avoid = os.getenv('FABRIC_AVOID')
 if not avoid or len(avoid) == 0:
     avoid = ["EDUKY"]
 
+
 def get_fablib(fabric_rc=fabric_rc):
     return FablibManager(fabric_rc=fabric_rc)
 
@@ -66,11 +67,11 @@ def create_slice(site, worker):
         with fim_lock:
             fablib = get_fablib()
 
-            slice_name = f"{SLICE_PREFIX}{site_name.lower()}-w{worker}-{int(time.time())}"
+            slice_name = f"{SLICE_PREFIX}-{worker}-{int(time.time())}"
             slice_obj = fablib.new_slice(name=slice_name)
             node = slice_obj.add_node(name="node", site=site_name, cores=4, ram=16, disk=100,
                                       image="docker_rocky_8",
-                                      host=f"{site_name.lower()}-w{worker}.fabric-testbed.net")
+                                      host=worker)
             node.add_fabnet(net_type="IPv4", nic_type='NIC_Basic')
             node.add_post_boot_upload_directory('../scripts/node_tools', '.')
             node.add_post_boot_execute('sudo node_tools/host_tune.sh')

--- a/tests/daily/test_iPerf.py
+++ b/tests/daily/test_iPerf.py
@@ -145,7 +145,7 @@ def test_site_worker_pair_ping_iperf(fablib):
     assert not failed and not failed_slices, (
         f"Some tests failed.\n"
         f"Failed slice pairs: {', '.join(failed.keys()) if failed else 'None'}\n"
-        f"Failed to create slices: {', '.join(failed_slices) if failed_slices else 'None'}"
+        f"Failed to create slices: {', '.join(failed_slices.keys()) if failed_slices else 'None'}"
     )
     print("TEST SUMMARY==========================================================================================")
 

--- a/tests/daily/test_iPerf.py
+++ b/tests/daily/test_iPerf.py
@@ -23,13 +23,12 @@
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
 import pytest
-from tests.utils import save_results_json
+from tests.utils import save_results_json, wait_and_configure_slices
 from tests.daily.slice_helper import (
     get_fablib,
     delete_existing_slices,
     get_sites_with_workers,
     create_site_worker_slices,
-    wait_and_configure_slices,
     get_site_pairs,
     collect_node_ips,
     run_remote_command,

--- a/tests/daily/test_iPerf.py
+++ b/tests/daily/test_iPerf.py
@@ -88,8 +88,8 @@ def test_site_worker_pair_ping_iperf(fablib):
             pair_result["ping"] = "PASS"
         else:
             pair_result["ping"] = f"FAIL: {ping_err or ping_out.strip().splitlines()[-1]}"
-            pair_result[slices[src].get_slice_name()] = slices[src].get_slice_id()
-            pair_result[slices[dst].get_slice_name()] = slices[dst].get_slice_id()
+            pair_result[slices[src].get_name()] = slices[src].get_slice_id()
+            pair_result[slices[dst].get_name()] = slices[dst].get_slice_id()
             slices_to_keep.append(slices[src].get_slice_id())
             slices_to_keep.append(slices[dst].get_slice_id())
 

--- a/tests/daily/test_iPerf.py
+++ b/tests/daily/test_iPerf.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 # Author: Komal Thareja (kthare10@renci.org)
 import pytest
+from tests.utils import save_results_json
 from tests.daily.slice_helper import (
     get_fablib,
     delete_existing_slices,
@@ -33,7 +34,6 @@ from tests.daily.slice_helper import (
     collect_node_ips,
     run_remote_command,
     cleanup_slices,
-    save_results_json
 )
 
 DOCKER_IMAGE = 'pruth/fabric-multitool-rockylinux9:latest'

--- a/tests/daily/test_iPerf.py
+++ b/tests/daily/test_iPerf.py
@@ -88,6 +88,8 @@ def test_site_worker_pair_ping_iperf(fablib):
             pair_result["ping"] = "PASS"
         else:
             pair_result["ping"] = f"FAIL: {ping_err or ping_out.strip().splitlines()[-1]}"
+            pair_result[slices[src].get_slice_name()] = slices[src].get_slice_id()
+            pair_result[slices[dst].get_slice_name()] = slices[dst].get_slice_id()
             slices_to_keep.append(slices[src].get_slice_id())
             slices_to_keep.append(slices[dst].get_slice_id())
 
@@ -104,6 +106,8 @@ def test_site_worker_pair_ping_iperf(fablib):
             pair_result["iperf3"] = "PASS"
         else:
             pair_result["iperf3"] = f"FAIL: {iperf_err or iperf_out.strip().splitlines()[-1]}"
+            pair_result[slices[src].get_slice_name()] = slices[src].get_slice_id()
+            pair_result[slices[dst].get_slice_name()] = slices[dst].get_slice_id()
             slices_to_keep.append(slices[src].get_slice_id())
             slices_to_keep.append(slices[dst].get_slice_id())
 

--- a/tests/daily/test_iPerf.py
+++ b/tests/daily/test_iPerf.py
@@ -64,6 +64,7 @@ def test_site_worker_pair_ping_iperf(fablib):
     pairs = get_site_pairs(slices)
 
     print("\nRunning ping and iperf3 tests across all slice pairs...")
+    slices_to_keep = []
 
     for src, dst in pairs:
         if src == dst:
@@ -88,6 +89,8 @@ def test_site_worker_pair_ping_iperf(fablib):
             pair_result["ping"] = "PASS"
         else:
             pair_result["ping"] = f"FAIL: {ping_err or ping_out.strip().splitlines()[-1]}"
+            slices_to_keep.append(slices[src].get_slice_id())
+            slices_to_keep.append(slices[dst].get_slice_id())
 
         # Start iperf3 server on destination
         iperf_cmd_server = f"docker run -d --rm --network host {DOCKER_IMAGE} iperf3 -s -1 > /dev/null 2>&1"
@@ -102,33 +105,47 @@ def test_site_worker_pair_ping_iperf(fablib):
             pair_result["iperf3"] = "PASS"
         else:
             pair_result["iperf3"] = f"FAIL: {iperf_err or iperf_out.strip().splitlines()[-1]}"
+            slices_to_keep.append(slices[src].get_slice_id())
+            slices_to_keep.append(slices[dst].get_slice_id())
 
         results[pair_key] = pair_result
 
     # Step 6: Save results
     save_results_json(results)
+    save_results_json(failed_slices, "slice_creation_failures.json")
 
     # Step 7: Summary and cleanup
+    print("TEST SUMMARY==========================================================================================")
     if failed_slices:
-        print("\nThe following slices failed to create:")
+        print("\nFAILED - Slice Creation")
         for s_name, error in failed_slices.items():
             print(f" - {s_name}: {error}")
     else:
-        print("\nAll slices created successfully.")
+        print("\nPASS - Slice Creation")
 
-    failed = {pair: r for pair, r in results.items() if "FAIL" in r["ping"] or "FAIL" in r["iperf3"]}
-    if failed:
-        print("\nFailures:")
-        for k, v in failed.items():
+    ping_failures = {pair: r for pair, r in results.items() if "FAIL" in r["ping"]}
+    if ping_failures or len(ping_failures):
+        print("\nFAILED - Ping")
+        for k, v in ping_failures.items():
             print(f"{k}: {v}")
     else:
-        print("\nAll site-worker pairs passed.")
-        cleanup_slices(slices)
+        print("\nPASS - Ping")
 
-    #assert not failed, f"Some slice pairs failed: {', '.join(failed.keys())}"
+    iperf3_failures = {pair: r for pair, r in results.items() if "FAIL" in r["iperf3"]}
+    if iperf3_failures or len(iperf3_failures):
+        print("\nFAILED - iPerf3")
+        for k, v in iperf3_failures.items():
+            print(f"{k}: {v}")
+    else:
+        print("\nPASS - iPerf3")
+
+    failed = {pair: r for pair, r in results.items() if "FAIL" in r["ping"] or "FAIL" in r["iperf3"]}
+    cleanup_slices(slices, slices_to_keep)
+
     assert not failed and not failed_slices, (
         f"Some tests failed.\n"
         f"Failed slice pairs: {', '.join(failed.keys()) if failed else 'None'}\n"
         f"Failed to create slices: {', '.join(failed_slices) if failed_slices else 'None'}"
     )
+    print("TEST SUMMARY==========================================================================================")
 

--- a/tests/daily/test_iPerf.py
+++ b/tests/daily/test_iPerf.py
@@ -106,8 +106,8 @@ def test_site_worker_pair_ping_iperf(fablib):
             pair_result["iperf3"] = "PASS"
         else:
             pair_result["iperf3"] = f"FAIL: {iperf_err or iperf_out.strip().splitlines()[-1]}"
-            pair_result[slices[src].get_slice_name()] = slices[src].get_slice_id()
-            pair_result[slices[dst].get_slice_name()] = slices[dst].get_slice_id()
+            pair_result[slices[src].get_name()] = slices[src].get_slice_id()
+            pair_result[slices[dst].get_name()] = slices[dst].get_slice_id()
             slices_to_keep.append(slices[src].get_slice_id())
             slices_to_keep.append(slices[dst].get_slice_id())
 

--- a/tests/system/test_smart_nic.py
+++ b/tests/system/test_smart_nic.py
@@ -28,11 +28,11 @@ from tests.base_test import BaseTest
 
 class SmartNicSliceTest(BaseTest):
     def setUp(self):
-        self.prefix = "Nvme"
+        self.prefix = "SmartNIc"
         super(SmartNicSliceTest, self).setUp()
 
     def test_slice(self):
-        site = self._fablib.get_random_site(filter_function=lambda x: x['nvme_available'] > 0)
+        site = self._fablib.get_random_site(filter_function=lambda x: x['nic_connectx_5_available'] > 0)
         print(f"site: {site}")
 
         node_name = 'Node1'
@@ -55,6 +55,15 @@ class SmartNicSliceTest(BaseTest):
 
         # VERIFICATION
         node.execute("sudo dnf install -y pciutils")
-        node.execute("sudo lspci")
+        cmd = "sudo dnf install -y -q pciutils && lspci | grep -i ConnectX"
+        stdout, stderr = node.execute(cmd)
+
+        if "ConnectX-6" not in stdout or "ConnectX-5" not in stdout:
+            raise Exception(f"Smart NIC not detected in lspci")
+
+        # Should see 4 entries: 2 cards × 2 ports
+        nic_count = stdout.count("Ethernet controller: Mellanox Technologies")
+        if nic_count < 2:
+            raise Exception(f"Expected >=2 NIC entries, found {nic_count}")
 
         self._slice.delete()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,10 @@
+import json
+
 from fabrictestbed_extensions.fablib.slice import Slice
 
 
-def error_message(slice_obj: Slice, exception: Exception):
-    if "Slice Exception" not in str(exception):
+def error_message(slice_obj: Slice, exception: Exception = None):
+    if exception and "Slice Exception" not in str(exception):
         return str(exception)
 
     cascade_notice_string1 = "Closing reservation due to failure in slice"
@@ -17,4 +19,12 @@ def error_message(slice_obj: Slice, exception: Exception):
 
         return ret_val
     except Exception:
-        return str(exception)
+        if exception:
+            return str(exception)
+        else:
+            return "Fail"
+
+
+def save_results_json(results, filename="iperf_test_results.json"):
+    with open(filename, "w") as f:
+        json.dump(results, f, indent=2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
 import json
+import random
+from itertools import combinations
 
 from fabrictestbed_extensions.fablib.slice import Slice
 
@@ -28,3 +30,26 @@ def error_message(slice_obj: Slice, exception: Exception = None):
 def save_results_json(results, filename="iperf_test_results.json"):
     with open(filename, "w") as f:
         json.dump(results, f, indent=2)
+
+
+def make_site_pairs(sites: list[str]):
+    """
+    Randomly select unique (site1, site2, worker1, worker2) pairs.
+
+    Constraints:
+    - site1 != site2
+    - No duplicate pairs (e.g., both (a, b) and (b, a))
+    - Each site must have at least one worker
+    - Number of pairs is len(sites) // 2
+    """
+    # Generate all valid (site1, site2) combinations
+    valid_pairs = [
+        (site1, site2)
+        for site1, site2 in combinations(sites, 2)
+    ]
+
+    count = len(sites) // 2
+    if count > len(valid_pairs):
+        raise ValueError(f"Cannot select {count} unique pairs from only {len(valid_pairs)} valid combinations.")
+
+    return random.sample(valid_pairs, count)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import json
 import random
+import traceback
 from itertools import combinations
 
 from fabrictestbed_extensions.fablib.slice import Slice
@@ -53,3 +54,21 @@ def make_site_pairs(sites: list[str]):
         raise ValueError(f"Cannot select {count} unique pairs from only {len(valid_pairs)} valid combinations.")
 
     return random.sample(valid_pairs, count)
+
+
+def wait_and_configure_slice(slice_object: Slice):
+    if not slice_object:
+        return
+    try:
+        slice_object.wait(progress=False)
+        slice_object.wait_ssh(progress=False)
+        slice_object.post_boot_config()
+    except Exception as e:
+        print(f"[{slice_object.get_name()}] Slice configuration error: {e}")
+        traceback.print_exc()
+
+
+def wait_and_configure_slices(slices):
+    for key, slice_obj in slices.items():
+        print(f"Waiting on slice {key}")
+        wait_and_configure_slice(slice_object=slice_obj)


### PR DESCRIPTION
## Summary

- **fabrictestbed-extensions 2.0.6 compatibility**: Replace removed `fablib` singleton import with `self._fablib`, replace deprecated `get_os_interface()` with `get_device_name()`, update dependency pins
- **Security hardening**: Add `_validate_ip()` and `_safe_devname()` helpers to `base_test.py`; sanitize all API-returned IPs and device names before shell interpolation in `node.execute()` calls across all test files
- **Test infrastructure improvements**: Extract shared utilities into `tests/utils.py` (`error_message`, `save_results_json`, `make_site_pairs`, `wait_and_configure_slices`); refactor FABNetv4/v6 tests to create one slice per site with pair-based ping testing; log slice IDs for failed tests; improve test summaries and cleanup
- **Test fixes**: Exclude EDC from l2bridge (single worker), remove CIEN from list sites, fix varying-size VM test, fix smart NIC test, skip maintenance sites/hosts, make installs non-interactive

## Test plan

- [ ] `grep -r "get_os_interface" tests/` returns no results
- [ ] `grep -r "from fabrictestbed_extensions.fablib.fablib import fablib" tests/` returns no results
- [ ] `python -m py_compile` passes on all modified files
- [ ] Run acceptance tests against live FABRIC environment
- [ ] Run system tests against live FABRIC environment
- [ ] Run daily iPerf tests against live FABRIC environment