### PR TITLE
Fix host enumeration for ResourcesV2 and unbound slice_obj in error handler

### DIFF
--- a/tests/acceptance/test_b_create_vm_varying_sizes.py
+++ b/tests/acceptance/test_b_create_vm_varying_sizes.py
@@ -67,14 +67,15 @@ def create_and_submit_slice(site):
 
         print(f"[{site_name}] Creating slice: {slice_name}")
         slice_obj = fablib.new_slice(name=slice_name)
-        site_obj = fablib.get_resources().get_site(site_name)
-        for h in site_obj.get_hosts().values():
-            if h.get_state() != "Active":
+        # ResourcesV2: get_site() returns a plain dict; hosts are exposed via
+        # get_hosts_by_site() as {host_name: host_dict}
+        for h in fablib.get_resources().get_hosts_by_site(site_name).values():
+            if h.get("state") != "Active":
                 continue
             slice_obj.add_node(
-                name=h.get_name(),
+                name=h.get("name"),
                 site=site_name,
-                host=h.get_name(),
+                host=h.get("name"),
                 cores=VM_CONFIG["cores"],
                 ram=VM_CONFIG["ram"],
                 disk=VM_CONFIG["disk"]
@@ -110,9 +111,11 @@ def test_non_blocking_vm_creation(fablib):
             except Exception as e:
                 print(f"[{site_name}] Error submitting slice: {e}")
                 traceback.print_exc()
+                # create_and_submit_slice raised, so no slice object exists for
+                # this site; record the failure without referencing one
                 results[site_name] = {"state": False,
-                                      "error": error_message(slice_obj=slice_obj, exception=e),
-                                      "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"}
+                                      "error": str(e),
+                                      "slice_id": site_name}
 
     wait_and_configure_slices(slice_objects)
 

--- a/tests/daily/slice_helper.py
+++ b/tests/daily/slice_helper.py
@@ -104,11 +104,12 @@ def create_site_worker_slices(fablib, sites):
                 continue
             if site.get("state") in avoid:
                 continue
-            site_obj = fablib.get_resources().get_site(site["name"])
-            for h in site_obj.get_hosts().values():
-                if h.get_state() != "Active":
+            # ResourcesV2: hosts are exposed via get_hosts_by_site() as
+            # {host_name: host_dict}
+            for h in fablib.get_resources().get_hosts_by_site(site["name"]).values():
+                if h.get("state") != "Active":
                     continue
-                f = executor.submit(create_slice, site, h.get_name())
+                f = executor.submit(create_slice, site, h.get("name"))
                 futures[f] = (site, h)
 
         for future in as_completed(futures):


### PR DESCRIPTION
## Problem

`AT-Dev-b_create_vm_varying_sizes` fails with fablib 2.x / `FabricManagerV2`:

1. `ResourcesV2.get_site()` returns a plain **dict**, not a `Site` object — `site_obj.get_hosts()` raises `AttributeError: 'dict' object has no attribute 'get_hosts'`. Hosts moved to `ResourcesV2.get_hosts_by_site(site_name)`, which returns `{host_name: host_dict}` with `name`/`state` keys.
2. The submit error handler in `test_non_blocking_vm_creation` referenced `slice_obj` after `future.result()` raised — `slice_obj` is never bound in that case, so the handler crashed with `UnboundLocalError` and killed the whole test instead of recording the per-site failure and continuing. This masks any transient per-site error, not just this one.

## Fix

- Enumerate hosts via `get_hosts_by_site()` and read dict keys (`state`, `name`) — fixed in `tests/acceptance/test_b_create_vm_varying_sizes.py` and the same pattern in `tests/daily/slice_helper.py`.
- Error handler records `str(e)` keyed by site name without referencing a slice object that does not exist.

Verified against `resources_v2.py` in fabrictestbed-extensions: `get_site()` (`:465`) returns `Optional[Dict]`, `get_hosts_by_site()` (`:566`) returns `{name: host_dict}`, and raw host dicts carry `name`/`state` (same keys `_host_summary_to_v1_dict` reads).