### PR TITLE
Tag L2PTP SmartNIC interfaces with VLAN; fix unbound slice_obj in all submission error handlers

### DIFF
--- a/tests/acceptance/test_c_create_nvme_vms.py
+++ b/tests/acceptance/test_c_create_nvme_vms.py
@@ -95,8 +95,8 @@ def test_create_nvme_vms_per_site(fablib):
                 print(f"[{site_name}] Slice submission error: {e}")
                 traceback.print_exc()
                 results[site_name] = {"state": False,
-                                      "error": error_message(slice_obj=slice_obj, exception=e),
-                                      "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"}
+                                      "error": str(e),
+                                      "slice_id": site_name}
 
     wait_and_configure_slices(slice_objects)
     for site_name, slice_obj in slice_objects.items():

--- a/tests/acceptance/test_d_create_shared_nic_vms.py
+++ b/tests/acceptance/test_d_create_shared_nic_vms.py
@@ -97,8 +97,8 @@ def test_create_shared_nic_vms_per_site(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": site_name
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_e_create_smart_nic_vms.py
+++ b/tests/acceptance/test_e_create_smart_nic_vms.py
@@ -100,8 +100,8 @@ def test_create_smartnic_vms_per_site(fablib):
                 traceback.print_exc()
                 results[key] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": key
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_f_create_storage_vms.py
+++ b/tests/acceptance/test_f_create_storage_vms.py
@@ -96,8 +96,8 @@ def test_attached_storage_parallel(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": site_name
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_g_fabnetv4_shared_nic.py
+++ b/tests/acceptance/test_g_fabnetv4_shared_nic.py
@@ -107,8 +107,8 @@ def test_fabnetv4_sharednic_ping(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": site_name
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_h_fabnetv6_shared_nic.py
+++ b/tests/acceptance/test_h_fabnetv6_shared_nic.py
@@ -107,7 +107,7 @@ def test_fabnetv6_sharednic_ping(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e)
+                    "error": str(e)
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_i_l2bridge_shared_nic.py
+++ b/tests/acceptance/test_i_l2bridge_shared_nic.py
@@ -112,8 +112,8 @@ def test_sharednic_local_bridge_reachability(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": site_name
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_j_l2bridge_smart_nic.py
+++ b/tests/acceptance/test_j_l2bridge_smart_nic.py
@@ -110,8 +110,8 @@ def test_smartnic_local_bridge_reachability(fablib):
                 traceback.print_exc()
                 results[site_name] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": site_name
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_k_l2ptp_smart_nic.py
+++ b/tests/acceptance/test_k_l2ptp_smart_nic.py
@@ -42,6 +42,10 @@ NIC_MODELS = {
 NETWORK_NAME = 'l2-PTP'
 SUBNET = IPv4Network("192.168.1.0/24")
 MAX_PARALLEL_TESTS = 3
+# L2PTP endpoints on dedicated SmartNIC ports must be VLAN-tagged: the Net AM
+# builds an NSO point-to-point circuit and rejects untagged interfaces
+# ("must be tagged (with vlan label in 1..4095)")
+VLAN_ID = "100"
 
 
 @pytest.fixture(scope="module")
@@ -72,11 +76,13 @@ def create_l2ptp_slice(site1, site2, nic_model):
                                    cores=VM_CONFIG["cores"], ram=VM_CONFIG["ram"], disk=VM_CONFIG["disk"])
         iface1 = node1.add_component(model=nic_model, name="nic1").get_interfaces()[0]
         iface1.set_mode("auto")
+        iface1.set_vlan(VLAN_ID)
 
         node2 = slice_obj.add_node(name="node2", site=site2,
                                    cores=VM_CONFIG["cores"], ram=VM_CONFIG["ram"], disk=VM_CONFIG["disk"])
         iface2 = node2.add_component(model=nic_model, name="nic2").get_interfaces()[0]
         iface2.set_mode("auto")
+        iface2.set_vlan(VLAN_ID)
 
         slice_obj.add_l2network(name=NETWORK_NAME, interfaces=[iface1, iface2], type='L2PTP', subnet=SUBNET)
         slice_obj.submit(wait=False)
@@ -126,8 +132,8 @@ def test_smartnic_l2ptp_across_sites(fablib):
                 traceback.print_exc()
                 results[key] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": key
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_l_l2sts_shared_nic.py
+++ b/tests/acceptance/test_l_l2sts_shared_nic.py
@@ -126,8 +126,8 @@ def test_l2sts_sharednic_ping(fablib):
                 traceback.print_exc()
                 results[key] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": key
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_m_l2sts_smart_nic.py
+++ b/tests/acceptance/test_m_l2sts_smart_nic.py
@@ -120,8 +120,8 @@ def test_l2sts_smartnic_ping(fablib):
                 traceback.print_exc()
                 results[key] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": key
                 }
 
     wait_and_configure_slices(slice_objects)

--- a/tests/acceptance/test_z_create_gpu_vms.py
+++ b/tests/acceptance/test_z_create_gpu_vms.py
@@ -118,8 +118,8 @@ def test_create_gpu_vms_per_site(fablib):
                 traceback.print_exc()
                 results[site_name_gpu_model] = {
                     "state": False,
-                    "error": error_message(slice_obj=slice_obj, exception=e),
-                    "slice_id": f"{slice_obj.get_name()}/{slice_obj.get_slice_id()}"
+                    "error": str(e),
+                    "slice_id": site_name_gpu_model
                 }
 
     wait_and_configure_slices(slice_objects)


### PR DESCRIPTION
## Problem

1. **test-k L2PTP fails at the Net AM**: `l2ptp - interface ... must be tagged (with vlan label in 1..4095)`. The NSO l2ptp point-to-point circuit requires an `outervlan` at each endpoint (`net_handler.__l2ptp_create_data` in AMHandlers) — unlike `l2bridge`/`l2sts`, which default untagged interfaces to `outervlan=0`. The test created L2PTP over dedicated SmartNIC ports without setting VLANs, so priming always fails.

2. **Latent `UnboundLocalError` in 12 more acceptance tests** — same bug fixed for test_b in #20: the submission-loop except block references `slice_obj` after `future.result()` raised (never bound), so a single submit failure crashes the whole multi-site test with `UnboundLocalError` instead of recording the per-site result. This is what turned the RENC floating-IP exhaustion into a full test crash in test_e today.

## Fix

- test_k: `set_vlan("100")` on both dedicated SmartNIC interfaces (same tag both ends; ports are dedicated so no conflict across concurrent slices).
- All submission-loop handlers: record `str(e)` keyed by the site/model key without referencing a slice object that doesn't exist. Validation-loop handlers (where `slice_obj` is the loop variable) are untouched.

## Verification

- Verified against AMHandlers `net_handler.py`: only l2ptp raises on missing vlan (`:506-508`); l2bridge (`:473`) and l2sts (`:571`) default to untagged.
- `py_compile` clean on all changed files; reviewed the full diff — only the 12 submission-loop blocks and the test_k VLAN lines changed.